### PR TITLE
docs: fix conflicting Effect language service plugin configuration

### DIFF
--- a/packages/website/docs/02-tsconfig.md
+++ b/packages/website/docs/02-tsconfig.md
@@ -76,13 +76,12 @@ Effect projects benefit from strict TypeScript configuration. Reference configur
 ```jsonc
 "plugins": [
   {
-    "name": "@effect/language-service",
-    "transform": "@effect/language-service/transform"
+    "name": "@effect/language-service"
   }
 ]
 ```
 
-Enables Effect language service for diagnostics and transforms.
+Enables Effect language service for editor diagnostics. For build-time diagnostics, run `bunx effect-language-service patch` (see [Project Setup](./01-project-setup.md)).
 
 ## Why These Settings?
 


### PR DESCRIPTION
Fixes the HIGH severity documentation conflict identified in #3

Removed the `transform` property from the Effect language service plugin configuration in `02-tsconfig.md` to align with the Option A approach (CLI patch) documented in the Project Setup guide.

**Changes:**
- Removed `"transform": "@effect/language-service/transform"` from plugin config
- Added clarifying note referencing the Project Setup guide for build-time diagnostics
- Ensures consistency between `01-project-setup.md` and `02-tsconfig.md`

Fixes #3

---
Generated with [Claude Code](https://claude.ai/code)