### PR TITLE
Improved readability

### DIFF
--- a/.changeset/improved-readability.md
+++ b/.changeset/improved-readability.md
@@ -1,0 +1,64 @@
+---
+"@effect-best-practices/website": patch
+---
+
+improved readability
+
+1. Refactored `Layer.effect` calls to reduce nesting. Changed from this
+
+   ```typescript
+   Layer.effect(
+     Service,
+     Effect.gen(function* () {
+       // ...
+     })
+   )
+   ```
+
+   to this
+
+   ```typescript
+   Effect.gen(function* () {
+     // ...
+   }).pipe(Layer.effect(Service))
+   ```
+
+2. Changed a few `Effect.fn` function definitions to reduce nesting. Changed from this
+
+   ```typescript
+   const fn = Effect.fn("fn name")((...args: any[]) =>
+     Effect.gen(function* () {
+       // ...
+     })
+   )
+   ```
+
+   to this
+
+   ```typescript
+   const fn = Effect.fn("fn name")(function* (...args: any[]) {
+     // ...
+   })
+   ```
+
+3. Removed unnecessary `Tag.of` calls directly inside `Layer.succeed` arguments. Changed from this
+
+   ```typescript
+   const Tag1Live = Layer.succeed(
+     Tag1,
+     Tag1.of({
+       // ...
+     })
+   );
+   ```
+
+   to this
+
+   ```typescript
+   const Tag1Live = Layer.succeed(Tag1, {
+     // ...
+   });
+   ```
+
+4. Added some missing `Tag1.of` calls
+5. Other improvements

--- a/packages/cli/src/open-issue-service.ts
+++ b/packages/cli/src/open-issue-service.ts
@@ -93,41 +93,38 @@ export class IssueService extends Context.Tag("@cli/IssueService")<
     ) => Effect.Effect<OpenIssueResult, BrowserOpenError>;
   }
 >() {
-  static readonly layer = Layer.effect(
-    IssueService,
-    Effect.gen(function* () {
-      const browser = yield* BrowserService;
+  static readonly layer = Effect.gen(function* () {
+    const browser = yield* BrowserService;
 
-      const open = Effect.fn("IssueService.open")((input: OpenIssueInput) =>
-        Effect.gen(function* () {
-          const repoUrl = "https://github.com/kitlangton/effect-solutions";
+    const open = Effect.fn("IssueService.open")(function* (
+      input: OpenIssueInput,
+    ) {
+      const repoUrl = "https://github.com/kitlangton/effect-solutions";
 
-          if (!input.category && !input.title && !input.description) {
-            const issueUrl = `${repoUrl}/issues/new`;
-            yield* browser.open(issueUrl);
-            return { issueUrl };
-          }
+      if (!input.category && !input.title && !input.description) {
+        const issueUrl = `${repoUrl}/issues/new`;
+        yield* browser.open(issueUrl);
+        return { issueUrl };
+      }
 
-          const fullTitle =
-            input.category && input.title
-              ? `[${input.category}] ${input.title}`
-              : input.title || "";
-          const body = input.description
-            ? `## Description\n\n${input.description}\n\n---\n*Created via [Effect Solutions CLI](${repoUrl})*`
-            : `---\n*Created via [Effect Solutions CLI](${repoUrl})*`;
+      const fullTitle =
+        input.category && input.title
+          ? `[${input.category}] ${input.title}`
+          : input.title || "";
+      const body = input.description
+        ? `## Description\n\n${input.description}\n\n---\n*Created via [Effect Solutions CLI](${repoUrl})*`
+        : `---\n*Created via [Effect Solutions CLI](${repoUrl})*`;
 
-          const params = new URLSearchParams();
-          if (fullTitle) params.set("title", fullTitle);
-          if (body) params.set("body", body);
+      const params = new URLSearchParams();
+      if (fullTitle) params.set("title", fullTitle);
+      if (body) params.set("body", body);
 
-          const issueUrl = `${repoUrl}/issues/new?${params.toString()}`;
-          yield* browser.open(issueUrl);
+      const issueUrl = `${repoUrl}/issues/new?${params.toString()}`;
+      yield* browser.open(issueUrl);
 
-          return { issueUrl };
-        }),
-      );
+      return { issueUrl };
+    });
 
-      return IssueService.of({ open });
-    }),
-  );
+    return IssueService.of({ open });
+  }).pipe(Layer.effect(IssueService));
 }

--- a/packages/cli/src/update-notifier.test.ts
+++ b/packages/cli/src/update-notifier.test.ts
@@ -54,15 +54,12 @@ describe("maybeNotifyUpdate (effect)", () => {
       "utf8",
     );
 
-    const testConfigLayer = Layer.succeed(
-      UpdateNotifierConfig,
-      UpdateNotifierConfig.of({
-        checkInterval: 1000 * 60 * 60 * 24,
-        timeout: 3000,
-        isCi: false,
-        homeDir: tmpHome,
-      }),
-    );
+    const testConfigLayer = Layer.succeed(UpdateNotifierConfig, {
+      checkInterval: 1000 * 60 * 60 * 24,
+      timeout: 3000,
+      isCi: false,
+      homeDir: tmpHome,
+    });
 
     const program = Effect.gen(function* () {
       const notifier = yield* UpdateNotifier;
@@ -89,15 +86,12 @@ describe("maybeNotifyUpdate (effect)", () => {
       "utf8",
     );
 
-    const testConfigLayer = Layer.succeed(
-      UpdateNotifierConfig,
-      UpdateNotifierConfig.of({
-        checkInterval: 1000 * 60 * 60 * 24,
-        timeout: 3000,
-        isCi: false,
-        homeDir: tmpHome,
-      }),
-    );
+    const testConfigLayer = Layer.succeed(UpdateNotifierConfig, {
+      checkInterval: 1000 * 60 * 60 * 24,
+      timeout: 3000,
+      isCi: false,
+      homeDir: tmpHome,
+    });
 
     const program = Effect.gen(function* () {
       const notifier = yield* UpdateNotifier;
@@ -124,15 +118,12 @@ describe("maybeNotifyUpdate (effect)", () => {
       "utf8",
     );
 
-    const testConfigLayer = Layer.succeed(
-      UpdateNotifierConfig,
-      UpdateNotifierConfig.of({
-        checkInterval: 1000 * 60 * 60 * 24,
-        timeout: 3000,
-        isCi: true,
-        homeDir: tmpHome,
-      }),
-    );
+    const testConfigLayer = Layer.succeed(UpdateNotifierConfig, {
+      checkInterval: 1000 * 60 * 60 * 24,
+      timeout: 3000,
+      isCi: true,
+      homeDir: tmpHome,
+    });
 
     const program = Effect.gen(function* () {
       const notifier = yield* UpdateNotifier;
@@ -158,15 +149,12 @@ describe("maybeNotifyUpdate (effect)", () => {
       "utf8",
     );
 
-    const testConfigLayer = Layer.succeed(
-      UpdateNotifierConfig,
-      UpdateNotifierConfig.of({
-        checkInterval: 1000 * 60 * 60 * 24,
-        timeout: 3000,
-        isCi: false,
-        homeDir: tmpHome,
-      }),
-    );
+    const testConfigLayer = Layer.succeed(UpdateNotifierConfig, {
+      checkInterval: 1000 * 60 * 60 * 24,
+      timeout: 3000,
+      isCi: false,
+      homeDir: tmpHome,
+    });
 
     const program = Effect.gen(function* () {
       const notifier = yield* UpdateNotifier;

--- a/packages/website/docs/04-services-and-layers.md
+++ b/packages/website/docs/04-services-and-layers.md
@@ -93,37 +93,34 @@ class Users extends Context.Tag("@app/Users")<
     readonly all: () => Effect.Effect<readonly User[]>
   }
 >() {
-  static readonly layer = Layer.effect(
-    Users,
-    Effect.gen(function* () {
-      // 1. yield* services you depend on
-      const http = yield* HttpClient.HttpClient
-      const analytics = yield* Analytics
+  static readonly layer = Effect.gen(function* () {
+    // 1. yield* services you depend on
+    const http = yield* HttpClient.HttpClient
+    const analytics = yield* Analytics
 
-      // 2. define the service methods with Effect.fn for call-site tracing
-      const findById = Effect.fn("Users.findById")(
-        function* (id: UserId) {
-          yield* analytics.track("user.find", { id })
-          const response = yield* http.get(`https://api.example.com/users/${id}`)
-          return yield* HttpClientResponse.schemaBodyJson(User)(response)
-        },
-        Effect.catchTag("ResponseError", (error) =>
-          error.response.status === 404
-            ? UserNotFoundError.make({ id })
-            : GenericUsersError.make({ id, error }),
-        ),
-      )
+    // 2. define the service methods with Effect.fn for call-site tracing
+    const findById = Effect.fn("Users.findById")(
+      function* (id: UserId) {
+        yield* analytics.track("user.find", { id })
+        const response = yield* http.get(`https://api.example.com/users/${id}`)
+        return yield* HttpClientResponse.schemaBodyJson(User)(response)
+      },
+      Effect.catchTag("ResponseError", (error) =>
+        error.response.status === 404
+          ? UserNotFoundError.make({ id })
+          : GenericUsersError.make({ id, error }),
+      ),
+    )
 
-      // Use Effect.fn even for nullary methods (thunks) to enable tracing
-      const all = Effect.fn("Users.all")(function* () {
-        const response = yield* http.get("https://api.example.com/users")
-        return yield* HttpClientResponse.schemaBodyJson(Schema.Array(User))(response)
-      })
-
-      // 3. return the service
-      return Users.of({ findById, all })
+    // Use Effect.fn even for nullary methods (thunks) to enable tracing
+    const all = Effect.fn("Users.all")(function* () {
+      const response = yield* http.get("https://api.example.com/users")
+      return yield* HttpClientResponse.schemaBodyJson(Schema.Array(User))(response)
     })
-  )
+
+    // 3. return the service
+    return Users.of({ findById, all })
+  }).pipe(Layer.effect(Users))
 }
 ```
 
@@ -200,40 +197,37 @@ class Events extends Context.Tag("@app/Events")<
     readonly register: (eventId: EventId, userId: UserId) => Effect.Effect<Registration>
   }
 >() {
-  static readonly layer = Layer.effect(
-    Events,
-    Effect.gen(function* () {
-      const users = yield* Users
-      const tickets = yield* Tickets
-      const emails = yield* Emails
+  static readonly layer = Effect.gen(function* () {
+    const users = yield* Users
+    const tickets = yield* Tickets
+    const emails = yield* Emails
 
-      const register = Effect.fn("Events.register")(
-        function* (eventId: EventId, userId: UserId) {
-          const user = yield* users.findById(userId)
-          const ticket = yield* tickets.issue(eventId, userId)
-          const now = yield* Clock.currentTimeMillis
+    const register = Effect.fn("Events.register")(
+      function* (eventId: EventId, userId: UserId) {
+        const user = yield* users.findById(userId)
+        const ticket = yield* tickets.issue(eventId, userId)
+        const now = yield* Clock.currentTimeMillis
 
-          const registration = Registration.make({
-            id: RegistrationId.make(crypto.randomUUID()),
-            eventId,
-            userId,
-            ticketId: ticket.id,
-            registeredAt: new Date(now),
-          })
+        const registration = Registration.make({
+          id: RegistrationId.make(crypto.randomUUID()),
+          eventId,
+          userId,
+          ticketId: ticket.id,
+          registeredAt: new Date(now),
+        })
 
-          yield* emails.send(
-            user.email,
-            "Event Registration Confirmed",
-            `Your ticket code: ${ticket.code}`
-          )
+        yield* emails.send(
+          user.email,
+          "Event Registration Confirmed",
+          `Your ticket code: ${ticket.code}`
+        )
 
-          return registration
-        }
-      )
+        return registration
+      }
+    )
 
-      return Events.of({ register })
-    })
-  )
+    return Events.of({ register })
+  }).pipe(Layer.effect(Events))
 }
 ```
 
@@ -422,10 +416,10 @@ class Counter extends Context.Tag("@app/Counter")<
 >() {
   static readonly layer = Layer.sync(Counter, () => {
     let count = 0
-    return {
+    return Counter.of({
       get: () => Effect.succeed(count),
       increment: () => Effect.sync(() => void count++),
-    }
+    })
   })
 }
 
@@ -461,10 +455,10 @@ class Counter extends Context.Tag("@app/Counter")<
 >() {
   static readonly layer = Layer.sync(Counter, () => {
     let count = 0
-    return {
+    return Counter.of({
       get: () => Effect.succeed(count),
       increment: () => Effect.sync(() => void count++),
-    }
+    })
   })
 }
 

--- a/packages/website/docs/07-config.md
+++ b/packages/website/docs/07-config.md
@@ -79,30 +79,23 @@ class ApiConfig extends Context.Tag("@app/ApiConfig")<
     readonly timeout: number
   }
 >() {
-  static readonly layer = Layer.effect(
-    ApiConfig,
-    Effect.gen(function* () {
-      const apiKey = yield* Config.redacted("API_KEY")
-      const baseUrl = yield* Config.string("API_BASE_URL").pipe(
-        Config.orElse(() => Config.succeed("https://api.example.com"))
-      )
-      const timeout = yield* Config.integer("API_TIMEOUT").pipe(
-        Config.orElse(() => Config.succeed(30000))
-      )
-
-      return ApiConfig.of({ apiKey, baseUrl, timeout })
-    })
-  )
+  static readonly layer = Effect.gen(function* () {
+    const apiKey = yield* Config.redacted("API_KEY")
+    const baseUrl = yield* Config.string("API_BASE_URL").pipe(
+      Config.orElse(() => Config.succeed("https://api.example.com"))
+    )
+    const timeout = yield* Config.integer("API_TIMEOUT").pipe(
+      Config.orElse(() => Config.succeed(30000))
+    )
+    return ApiConfig.of({ apiKey, baseUrl, timeout })
+  }).pipe(Layer.effect(ApiConfig))
 
   // For tests - hardcoded values
-  static readonly testLayer = Layer.succeed(
-    ApiConfig,
-    ApiConfig.of({
-      apiKey: Redacted.make("test-key"),
-      baseUrl: "https://test.example.com",
-      timeout: 5000,
-    })
-  )
+  static readonly testLayer = Layer.succeed(ApiConfig, {
+    apiKey: Redacted.make("test-key"),
+    baseUrl: "https://test.example.com",
+    timeout: 5000,
+  })
 }
 ```
 
@@ -277,14 +270,11 @@ class ApiConfig extends Context.Tag("@app/ApiConfig")<
     readonly baseUrl: string
   }
 >() {
-  static readonly layer = Layer.effect(
-    ApiConfig,
-    Effect.gen(function* () {
-      const apiKey = yield* Config.redacted("API_KEY")
-      const baseUrl = yield* Config.string("API_BASE_URL")
-      return ApiConfig.of({ apiKey, baseUrl })
-    })
-  )
+  static readonly layer = Effect.gen(function* () {
+    const apiKey = yield* Config.redacted("API_KEY")
+    const baseUrl = yield* Config.string("API_BASE_URL")
+    return ApiConfig.of({ apiKey, baseUrl })
+  }).pipe(Layer.effect(ApiConfig))
 }
 
 const program = Effect.gen(function* () {
@@ -377,16 +367,13 @@ class DatabaseConfig extends Context.Tag("@app/DatabaseConfig")<
     readonly password: Redacted.Redacted
   }
 >() {
-  static readonly layer = Layer.effect(
-    DatabaseConfig,
-    Effect.gen(function* () {
-      const host = yield* Schema.Config("DB_HOST", Schema.String)
-      const port = yield* Schema.Config("DB_PORT", Port)
-      const database = yield* Schema.Config("DB_NAME", Schema.String)
-      const password = yield* Schema.Config("DB_PASSWORD", Schema.Redacted(Schema.String))
+  static readonly layer = Effect.gen(function* () {
+    const host = yield* Schema.Config("DB_HOST", Schema.String)
+    const port = yield* Schema.Config("DB_PORT", Port)
+    const database = yield* Schema.Config("DB_NAME", Schema.String)
+    const password = yield* Schema.Config("DB_PASSWORD", Schema.Redacted(Schema.String))
 
-      return DatabaseConfig.of({ host, port, database, password })
-    })
-  )
+    return DatabaseConfig.of({ host, port, database, password })
+  }).pipe(Layer.effect(DatabaseConfig))
 }
 ```

--- a/tests/07-config.test.ts
+++ b/tests/07-config.test.ts
@@ -75,29 +75,23 @@ describe("07-config", () => {
             readonly timeout: number;
           }
         >() {
-          static readonly layer = Layer.effect(
-            ApiConfig,
-            Effect.gen(function* () {
-              const apiKey = yield* Config.redacted("API_KEY");
-              const baseUrl = yield* Config.string("API_BASE_URL").pipe(
-                Config.orElse(() => Config.succeed("https://api.example.com")),
-              );
-              const timeout = yield* Config.integer("API_TIMEOUT").pipe(
-                Config.orElse(() => Config.succeed(30000)),
-              );
+          static readonly layer = Effect.gen(function* () {
+            const apiKey = yield* Config.redacted("API_KEY");
+            const baseUrl = yield* Config.string("API_BASE_URL").pipe(
+              Config.orElse(() => Config.succeed("https://api.example.com")),
+            );
+            const timeout = yield* Config.integer("API_TIMEOUT").pipe(
+              Config.orElse(() => Config.succeed(30000)),
+            );
 
-              return ApiConfig.of({ apiKey, baseUrl, timeout });
-            }),
-          );
+            return ApiConfig.of({ apiKey, baseUrl, timeout });
+          }).pipe(Layer.effect(ApiConfig));
 
-          static readonly testLayer = Layer.succeed(
-            ApiConfig,
-            ApiConfig.of({
-              apiKey: Redacted.make("test-key"),
-              baseUrl: "https://test.example.com",
-              timeout: 5000,
-            }),
-          );
+          static readonly testLayer = Layer.succeed(ApiConfig, {
+            apiKey: Redacted.make("test-key"),
+            baseUrl: "https://test.example.com",
+            timeout: 5000,
+          });
         }
 
         const program = Effect.gen(function* () {
@@ -127,16 +121,13 @@ describe("07-config", () => {
             readonly database: string;
           }
         >() {
-          static readonly layer = Layer.effect(
-            DbConfig,
-            Effect.gen(function* () {
-              const host = yield* Config.string("DB_HOST");
-              const port = yield* Config.integer("DB_PORT");
-              const database = yield* Config.string("DB_NAME");
+          static readonly layer = Effect.gen(function* () {
+            const host = yield* Config.string("DB_HOST");
+            const port = yield* Config.integer("DB_PORT");
+            const database = yield* Config.string("DB_NAME");
 
-              return DbConfig.of({ host, port, database });
-            }),
-          );
+            return DbConfig.of({ host, port, database });
+          }).pipe(Layer.effect(DbConfig));
         }
 
         const testConfig = ConfigProvider.fromMap(
@@ -408,23 +399,20 @@ describe("07-config", () => {
             readonly features: { enableCache: boolean };
           }
         >() {
-          static readonly layer = Layer.effect(
-            AppConfig,
-            Effect.gen(function* () {
-              const port = yield* Config.integer("PORT");
-              const host = yield* Config.string("HOST");
-              const dbUrl = yield* Config.string("DATABASE_URL");
-              const enableCache = yield* Config.boolean("ENABLE_CACHE").pipe(
-                Config.orElse(() => Config.succeed(false)),
-              );
+          static readonly layer = Effect.gen(function* () {
+            const port = yield* Config.integer("PORT");
+            const host = yield* Config.string("HOST");
+            const dbUrl = yield* Config.string("DATABASE_URL");
+            const enableCache = yield* Config.boolean("ENABLE_CACHE").pipe(
+              Config.orElse(() => Config.succeed(false)),
+            );
 
-              return AppConfig.of({
-                server: { port, host },
-                database: { url: dbUrl },
-                features: { enableCache },
-              });
-            }),
-          );
+            return AppConfig.of({
+              server: { port, host },
+              database: { url: dbUrl },
+              features: { enableCache },
+            });
+          }).pipe(Layer.effect(AppConfig));
         }
 
         const testConfig = ConfigProvider.fromMap(

--- a/tests/08-testing.test.ts
+++ b/tests/08-testing.test.ts
@@ -194,43 +194,40 @@ class Events extends Context.Tag("@app/Events")<
     ) => Effect.Effect<Registration, UserNotFound>;
   }
 >() {
-  static readonly layer = Layer.effect(
-    Events,
-    Effect.gen(function* () {
-      const users = yield* Users;
-      const tickets = yield* Tickets;
-      const emails = yield* Emails;
+  static readonly layer = Effect.gen(function* () {
+    const users = yield* Users;
+    const tickets = yield* Tickets;
+    const emails = yield* Emails;
 
-      const register = Effect.fn("Events.register")(function* (
-        eventId: EventId,
-        userId: UserId,
-      ) {
-        const user = yield* users.findById(userId);
-        const ticket = yield* tickets.issue(eventId, userId);
-        const now = yield* Clock.currentTimeMillis;
+    const register = Effect.fn("Events.register")(function* (
+      eventId: EventId,
+      userId: UserId,
+    ) {
+      const user = yield* users.findById(userId);
+      const ticket = yield* tickets.issue(eventId, userId);
+      const now = yield* Clock.currentTimeMillis;
 
-        const registration = Registration.make({
-          id: RegistrationId.make(crypto.randomUUID()),
-          eventId,
-          userId,
-          ticketId: ticket.id,
-          registeredAt: new Date(now),
-        });
-
-        yield* emails.send(
-          Email.make({
-            to: user.email,
-            subject: "Event Registration Confirmed",
-            body: `Your ticket code: ${ticket.code}`,
-          }),
-        );
-
-        return registration;
+      const registration = Registration.make({
+        id: RegistrationId.make(crypto.randomUUID()),
+        eventId,
+        userId,
+        ticketId: ticket.id,
+        registeredAt: new Date(now),
       });
 
-      return Events.of({ register });
-    }),
-  );
+      yield* emails.send(
+        Email.make({
+          to: user.email,
+          subject: "Event Registration Confirmed",
+          body: `Your ticket code: ${ticket.code}`,
+        }),
+      );
+
+      return registration;
+    });
+
+    return Events.of({ register });
+  }).pipe(Layer.effect(Events));
 }
 
 // provideMerge exposes leaf services in tests for setup/assertions


### PR DESCRIPTION
1. Refactored `Layer.effect` calls to reduce nesting. Changed from this

   ```typescript
   Layer.effect(
     Service,
     Effect.gen(function* () {
       // ...
     })
   )
   ```

   to this

   ```typescript
   Effect.gen(function* () {
     // ...
   }).pipe(Layer.effect(Service))
   ```

2. Changed a few `Effect.fn` function definitions to reduce nesting. Changed from this

   ```typescript
   const fn = Effect.fn("fn name")((...args: any[]) =>
     Effect.gen(function* () {
       // ...
     })
   )
   ```

   to this

   ```typescript
   const fn = Effect.fn("fn name")(function* (...args: any[]) {
     // ...
   })
   ```

3. Removed unnecessary `Tag.of` calls directly inside `Layer.succeed` arguments. Changed from this

   ```typescript
   const Tag1Live = Layer.succeed(
     Tag1,
     Tag1.of({
       // ...
     })
   );
   ```

   to this

   ```typescript
   const Tag1Live = Layer.succeed(Tag1, {
     // ...
   });
   ```

4. Added some missing `Tag1.of` calls
5. Other improvements