### PR TITLE
feat: disable auto capitalization in terminal demo

### DIFF
--- a/packages/website/src/components/mdx/Terminal/index.tsx
+++ b/packages/website/src/components/mdx/Terminal/index.tsx
@@ -421,6 +421,7 @@ export function TerminalDemo() {
               onBlur={() => setIsFocused(false)}
               className="absolute inset-0 opacity-0 w-full cursor-text"
               autoComplete="off"
+              autoCapitalize="none"
               spellCheck={false}
               disabled={isRunning}
             />


### PR DESCRIPTION
Extremely minor – noticed on mobile Safari I need to unclick the shift every time I entered a command within the terminal demo since its case sensitive, and by default iOS seems to start the input with a capital letter.

Loving the polish! Figured I'd send a PR in the spirit of such polish.

## Preview

### Before

https://github.com/user-attachments/assets/2cbd6573-e9c0-43eb-84a0-80a0f1c3141b

### After

https://github.com/user-attachments/assets/fce64d43-de8c-45b1-93af-7c2b910b772e

