### PR TITLE
Fix link typo

### DIFF
--- a/packages/website/docs/04-services-and-layers.md
+++ b/packages/website/docs/04-services-and-layers.md
@@ -246,7 +246,7 @@ Benefits:
 - Type-checks immediately even though leaf services aren't implemented yet.
 - Adding production implementations later doesn't change Events code.
 
-See [Testing with Vitest](/testing-with-vitest#worked-example-testing-a-service) for a complete worked example testing this `Events` service with test layers.
+See [Testing with Vitest](./08-testing.md#worked-example-testing-a-service) for a complete worked example testing this `Events` service with test layers.
 
 ## Test Implementations
 


### PR DESCRIPTION
This PR fixes a broken link on:
https://www.effect.solutions/services-and-layers

The page currently points to:
/testing-with-vitest#worked-example-testing-a-service

…which ends in heartbreak:

<img width="1327" height="751" alt="image" src="https://github.com/user-attachments/assets/01aab839-519d-4945-a135-751e5263e62e" />

The link is updated to the correct Testing doc (08), restoring the intended routing and pathing:

<img width="1280" height="952" alt="image" src="https://github.com/user-attachments/assets/4b584d43-ba3c-4a71-88dd-a6fb148c2d6e" />