### PR TITLE
Strengthen the visual affordance for interactive elements

### DIFF
--- a/.changeset/strengthen-the-visual-affordance-for-interactive-elements.md
+++ b/.changeset/strengthen-the-visual-affordance-for-interactive-elements.md
@@ -1,0 +1,5 @@
+---
+"@effect-best-practices/website": patch
+---
+
+Strengthen the visual affordance for interactive elements

--- a/packages/website/src/app/globals.css
+++ b/packages/website/src/app/globals.css
@@ -30,7 +30,7 @@
   }
 
   a {
-    @apply text-inherit no-underline cursor-auto;
+    @apply text-inherit no-underline;
   }
 
   a:hover {

--- a/packages/website/src/components/DocFooter.tsx
+++ b/packages/website/src/components/DocFooter.tsx
@@ -34,7 +34,7 @@ export function DocFooter({ docTitles, orderedSlugs }: DocFooterProps) {
             href={KIT_TWITTER_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 text-sm font-normal uppercase tracking-wider text-neutral-500 hover:text-neutral-300 no-underline !select-none cursor-default"
+            className="flex items-center gap-2 text-sm font-normal uppercase tracking-wider text-neutral-500 hover:text-neutral-300 no-underline !select-none"
             onMouseEnter={() => {
               setIsKitHovered(true);
               playHoverSfx();
@@ -87,7 +87,7 @@ export function DocFooter({ docTitles, orderedSlugs }: DocFooterProps) {
           prevSlug && prevTitle ? (
             <Link
               href={`/${prevSlug}`}
-              className="flex items-center gap-3 text-sm font-normal uppercase tracking-wider text-neutral-500 hover:text-neutral-300 no-underline !select-none cursor-default"
+              className="flex items-center gap-3 text-sm font-normal uppercase tracking-wider text-neutral-500 hover:text-neutral-300 no-underline !select-none"
               onMouseEnter={playHoverSfx}
               onClick={playClickSfx}
             >
@@ -97,7 +97,7 @@ export function DocFooter({ docTitles, orderedSlugs }: DocFooterProps) {
           ) : (
             <Link
               href="/"
-              className="flex items-center gap-3 text-sm font-normal uppercase tracking-wider text-neutral-500 hover:text-neutral-300 no-underline !select-none cursor-default"
+              className="flex items-center gap-3 text-sm font-normal uppercase tracking-wider text-neutral-500 hover:text-neutral-300 no-underline !select-none"
               onMouseEnter={playHoverSfx}
               onClick={playClickSfx}
             >
@@ -111,7 +111,7 @@ export function DocFooter({ docTitles, orderedSlugs }: DocFooterProps) {
         {nextSlug && nextTitle ? (
           <Link
             href={`/${nextSlug}`}
-            className="flex items-center gap-3 text-sm font-normal uppercase tracking-wider text-neutral-500 hover:text-neutral-300 no-underline !select-none cursor-default"
+            className="flex items-center gap-3 text-sm font-normal uppercase tracking-wider text-neutral-500 hover:text-neutral-300 no-underline !select-none"
             onMouseEnter={playHoverSfx}
             onClick={playClickSfx}
           >

--- a/packages/website/src/components/DocHeader.tsx
+++ b/packages/website/src/components/DocHeader.tsx
@@ -193,7 +193,7 @@ export function DocHeader({ docTitles }: DocHeaderProps) {
       <div className="max-w-screen-md mx-auto border-x border-neutral-800 flex items-center justify-between h-full">
         <Link
           href="/"
-          className="group flex-1 h-full cursor-default"
+          className="group flex-1 h-full"
           onBlur={handleBlur}
           onClick={handleClick}
           onFocus={handleFocus}
@@ -254,7 +254,7 @@ export function DocHeader({ docTitles }: DocHeaderProps) {
           type="button"
           onClick={handleToggleMute}
           onMouseEnter={handleMuteButtonHover}
-          className="flex items-center justify-center h-16 w-16 py-6 border-l border-neutral-800 hover:bg-neutral-900/50"
+          className="flex items-center justify-center h-16 w-16 py-6 border-l border-neutral-800 hover:bg-neutral-900/50 cursor-pointer"
           aria-label={isMuted ? "Unmute sounds" : "Mute sounds"}
         >
           {isMuted ? (

--- a/packages/website/src/components/DocList.tsx
+++ b/packages/website/src/components/DocList.tsx
@@ -235,7 +235,7 @@ export function DocList({ docs }: DocListProps) {
           Begin with{" "}
           <Link
             href="/quick-start"
-            className="group text-blue-400 hover:text-blue-300 no-underline cursor-pointer inline-flex items-center gap-1"
+            className="group text-blue-400 hover:text-blue-300 no-underline inline-flex items-center gap-1"
             onMouseEnter={handleMouseEnter}
             onClick={handleClick}
           >
@@ -279,7 +279,7 @@ export function DocList({ docs }: DocListProps) {
                     }}
                     aria-selected={selectedIndex === currentIndex}
                     className={cn(
-                      "block px-6 py-8 hover:bg-neutral-900/50 cursor-default focus:outline-none focus-visible:outline-none",
+                      "block px-6 py-8 hover:bg-neutral-900/50 focus:outline-none focus-visible:outline-none",
                       selectedIndex === currentIndex && "bg-neutral-900",
                     )}
                     style={{

--- a/packages/website/src/components/EffectOrFooter.tsx
+++ b/packages/website/src/components/EffectOrFooter.tsx
@@ -45,7 +45,7 @@ export function EffectOrFooter() {
                 href="https://effect.website"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="hover:text-neutral-400 transition-colors cursor-default"
+                className="hover:text-neutral-400 transition-colors"
                 {...navSfxProps}
               >
                 {word}
@@ -60,7 +60,7 @@ export function EffectOrFooter() {
         href="https://effect.website/docs/error-management/unexpected-errors/#ordie"
         target="_blank"
         rel="noopener noreferrer"
-        className="hover:text-neutral-400 transition-colors cursor-default"
+        className="hover:text-neutral-400 transition-colors"
         {...navSfxProps}
       >
         <SkullIcon className="h-4 w-4" weight="fill" />

--- a/packages/website/src/components/mdx/MDXLink.tsx
+++ b/packages/website/src/components/mdx/MDXLink.tsx
@@ -24,7 +24,7 @@ export function MDXLink(props: MDXLinkProps) {
     "text-blue-400/70 group-hover:text-blue-300/70 font-bold";
 
   const linkClassName = cn(
-    "group text-blue-400 hover:text-blue-300 no-underline cursor-pointer inline-flex items-center gap-1",
+    "group text-blue-400 hover:text-blue-300 no-underline inline-flex items-center gap-1",
     className,
   );
 

--- a/packages/website/src/mdx-components.tsx
+++ b/packages/website/src/mdx-components.tsx
@@ -162,7 +162,7 @@ export function useMDXComponents(
             }}
           />
           <a
-            className="group/anchor flex items-center gap-3 px-6 text-inherit no-underline hover:opacity-90 cursor-default"
+            className="group/anchor flex items-center gap-3 px-6 text-inherit no-underline hover:opacity-90 cursor-pointer"
             href={headingId ? `#${headingId}` : undefined}
             aria-label={headingId ? `Link to section ${headingId}` : undefined}
           >


### PR DESCRIPTION
Optimized accessibility by restoring the browsers visual affordance for links and strengthened the visual affordances for interactive buttons. This is an enhancement to the "audio" affordance for people who can’t rely on hover sounds alone or for those who have color vision deficiency and insufficient color contrast issues.

To accomplish this the global anchor rule `cursor-auto` was removed so anchors inherit the default browser pointer behavior. In addition, the footer nav, doc list entries, MDX inline links, and EffectOr CTAs no longer override the browser default cursor behavior. For components that aren’t native anchors, the pointer affordance was explicitly set.

![effect-solutions-01](https://github.com/user-attachments/assets/c8f87b5e-a347-48f1-8c93-cef8e4ada410)
