### PR TITLE
Update .vscode/settings.json TypeScript keys

### DIFF
--- a/.changeset/update-typescript-keys-in-vscode-settings.md
+++ b/.changeset/update-typescript-keys-in-vscode-settings.md
@@ -1,0 +1,5 @@
+---
+"effect-solutions": patch
+---
+
+Update TypeScript keys in `.vscode/settings.json`.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "files.watcherExclude": {
     "**/target": true
   },

--- a/packages/website/docs/01-project-setup.md
+++ b/packages/website/docs/01-project-setup.md
@@ -52,8 +52,8 @@ Your editor must use the **workspace** TypeScript version (not its built-in one)
 
 ```json
 {
-  "typescript.tsdk": "./node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
 }
 ```
 


### PR DESCRIPTION
When following the [project setup guide](https://www.effect.solutions/project-setup), the following deprecation warning is shown: 

<img width="761" height="267" alt="image" src="https://github.com/user-attachments/assets/4fd4d530-5d81-4639-a3a4-315c3e3ac905" />


This PR replaces the legacy `typescript.*` VS Code settings with the new `js/ts.*` keys in `.vscode/settings.json` and updates the documentation ([packages/website/docs/01-project-setup.md](https://github.com/kitlangton/effect-solutions/blob/main/packages/website/docs/01-project-setup.md)) to match.

See [Using the workspace version of TypeScript](https://code.visualstudio.com/docs/typescript/typescript-transpiling#_using-the-workspace-version-of-typescript) in the VS Code TypeScript docs and https://github.com/microsoft/vscode/pull/297076 for reference.