### PR TITLE
pin Effect packages to 4.0.0-beta.57 and migrate ServiceMap to Context.Service

### DIFF
--- a/.changeset/fix-cli-compatibility-with-latest-effect-beta.md
+++ b/.changeset/fix-cli-compatibility-with-latest-effect-beta.md
@@ -1,5 +1,0 @@
----
-"effect-solutions": patch
----
-
-fix cli compatibility with latest effect beta

--- a/.changeset/fix-cli-compatibility-with-latest-effect-beta.md
+++ b/.changeset/fix-cli-compatibility-with-latest-effect-beta.md
@@ -1,0 +1,5 @@
+---
+"effect-solutions": patch
+---
+
+fix cli compatibility with latest effect beta

--- a/.changeset/update-effect-beta-51-and-context-service.md
+++ b/.changeset/update-effect-beta-51-and-context-service.md
@@ -1,0 +1,5 @@
+---
+"effect-solutions": patch
+---
+
+update Effect to 4.0.0-beta.51 and migrate `ServiceMap.Service` to `Context.Service`

--- a/.changeset/update-effect-beta-51-and-context-service.md
+++ b/.changeset/update-effect-beta-51-and-context-service.md
@@ -1,5 +1,0 @@
----
-"effect-solutions": patch
----
-
-update Effect to 4.0.0-beta.51 and migrate `ServiceMap.Service` to `Context.Service`

--- a/.changeset/update-effect-beta-52-and-context-service.md
+++ b/.changeset/update-effect-beta-52-and-context-service.md
@@ -1,0 +1,5 @@
+---
+"effect-solutions": patch
+---
+
+update Effect to 4.0.0-beta.52, migrate `ServiceMap.Service` to `Context.Service`, and remove the old `Config.array` example

--- a/.changeset/update-effect-beta-52-and-context-service.md
+++ b/.changeset/update-effect-beta-52-and-context-service.md
@@ -1,5 +1,0 @@
----
-"effect-solutions": patch
----
-
-update Effect to 4.0.0-beta.52, migrate `ServiceMap.Service` to `Context.Service`, and remove the old `Config.array` example

--- a/.changeset/update-effect-beta-57-and-context-service.md
+++ b/.changeset/update-effect-beta-57-and-context-service.md
@@ -1,0 +1,5 @@
+---
+"effect-solutions": patch
+---
+
+pin Effect packages to 4.0.0-beta.57, migrate `ServiceMap.Service` to `Context.Service`, and remove the old `Config.array` example

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ This is a living document that intentionally posts "wrong answers" to get better
 1. Fork and clone the repo
 2. Create a feature branch
 3. Make your changes
-4. Run `bun run check` and `bun test`
+4. Run `bun run check` and `bun run test` (`bun run check` applies Biome fixes)
 5. Create a changeset: `bun scripts/changeset-named.ts "description"`
 6. Submit a PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ This is a living document that intentionally posts "wrong answers" to get better
 1. Fork and clone the repo
 2. Create a feature branch
 3. Make your changes
-4. Run `bun run check` and `bun run test` (`bun run check` applies Biome fixes)
+4. Run `bun run check` and `bun run test`
 5. Create a changeset: `bun scripts/changeset-named.ts "description"`
 6. Submit a PR
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,16 +9,16 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-visually-hidden": "^1.2.4",
         "cmdk": "^1.1.1",
-        "effect": "beta",
+        "effect": "4.0.0-beta.52",
         "ink": "^6.8.0",
         "next-mdx-remote": "^6.0.0",
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
-        "@effect/platform-bun": "beta",
-        "@effect/platform-node": "beta",
-        "@effect/vitest": "beta",
+        "@effect/platform-bun": "4.0.0-beta.52",
+        "@effect/platform-node": "4.0.0-beta.52",
+        "@effect/vitest": "4.0.0-beta.52",
         "vitest": "^4.1.0",
       },
     },
@@ -45,7 +45,7 @@
       "name": "@effect-best-practices/website",
       "version": "0.5.2",
       "dependencies": {
-        "@effect/platform-browser": "beta",
+        "@effect/platform-browser": "4.0.0-beta.52",
         "@phosphor-icons/react": "^2.1.10",
         "@tailwindcss/typography": "^0.5.19",
         "@vercel/analytics": "^2.0.1",
@@ -175,15 +175,15 @@
 
     "@effect/language-service": ["@effect/language-service@0.80.0", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-dKMATT1fDzaCpNrICpXga7sjJBtFLpKCAoE/1MiGXI8UwcHA9rmAZ2t52JO9g/kJpERWyomkJ+rl+VFlwNIofg=="],
 
-    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-beta.51", "", { "dependencies": { "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^4.0.0-beta.51" } }, "sha512-v7Zpjot3EvHSy4o+VNF/jGF2hxWCaCOdFmljJnweszrDHoTzu+mHGRYGN1CKLxOchwAuSnIDUwIVZ5Q6E0bBcA=="],
+    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-beta.52", "", { "dependencies": { "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^4.0.0-beta.52" } }, "sha512-/5JVgK3NqiRF/8sHhJnzc6QjPxRvsRoe7ZJkH1NitnUXNn0nZHFwTOOM8Vn1Wd1v2SUeOnWbMh3n/FuvvyEtKw=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.51", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.51" }, "peerDependencies": { "effect": "^4.0.0-beta.51" } }, "sha512-jXLrwDvItGWWGljua80tBJyacvnDVBXueKbrOSWUStmwElIFH/mXtkG7lpwX+im5WSJeWaw5xidTW11HnCaGLA=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.52", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.52" }, "peerDependencies": { "effect": "^4.0.0-beta.52" } }, "sha512-Y1+2noV0Qt+tKL2oHQwm536SaPfig/hB0He45VdCphTUdz5OO9VcLZqLEfNRxFwttlJPWpOkm4HvKUQwcj/6TQ=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.51", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.51", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.51", "ioredis": "^5.7.0" } }, "sha512-ChkyABVJ35Eo2yQD3zSL6qvw9hTFZ/ikrGVoIm6rbAN3091XOs8hGMF8f1iyeUAXochjcTvz+tg+5jUNw7Ig8g=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.52", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.52", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.52", "ioredis": "^5.7.0" } }, "sha512-IFloMd95ot9SACJXPSVG060evsKSnGXlMqwQdyhSmsi7zMwiwbioItw1Up+EK5gJj7m3TRHO6b7fErqVgsN2kQ=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.51", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.51" } }, "sha512-Dy59kDf0UNiHImDN90edoNWbdpdbDqioVjjAPqKTOdebiVEHlD9bUSNTYsSnKrqa/6WU53AWOP0SYwJ1aKKk4Q=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.52", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.52" } }, "sha512-f4e0LD/VSlIWBRkjtaJ+zFDRZsdD4Fs3zPhvnkHn+N8qpAJ+HQ00oN5Zye7KJONPEI1JHUt2HwtbHeGCdnBFAw=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.51", "", { "peerDependencies": { "effect": "^4.0.0-beta.51", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-vRNwI8G3PdtVz+9cDmE8+KCbAp+2hGMa2ZSaqrb1yzBt0ZBltl1wLzRa9C5sf7Ite9B1euQpQN6+xEe+y2Gdqw=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.52", "", { "peerDependencies": { "effect": "^4.0.0-beta.52", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-xFHdZ9iwfbtfsqKEli0ZrowLijosWh3QUnVYvV3gxkWuU2oMfgG/FiA6jw9b2UkdqKA+X9uUFwBALVFK59ncKA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -735,7 +735,7 @@
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
-    "effect": ["effect@4.0.0-beta.51", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-Xo4MDGMhAAw/jPTT5zYk1H2FnllAVsSdZWLag+0yY4Hi1rksgReE2M4vFdqgl9wPV+30wVMvd95oPAczs71HIg=="],
+    "effect": ["effect@4.0.0-beta.52", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-Aa9T5CEV3pCoSDM8sOnalwYieJi5olb7vn8TbgMB3U1YGEOG9ypogng33qMFLKswZM2UimwrXL9Ri1x9Jo9z6w=="],
 
     "effect-solutions": ["effect-solutions@workspace:packages/cli"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/cli": {
       "name": "effect-solutions",
-      "version": "0.4.19",
+      "version": "0.5.2",
       "bin": {
         "effect-solutions": "./bin.js",
       },
@@ -43,7 +43,7 @@
     },
     "packages/website": {
       "name": "@effect-best-practices/website",
-      "version": "0.4.19",
+      "version": "0.5.2",
       "dependencies": {
         "@effect/platform-browser": "beta",
         "@phosphor-icons/react": "^2.1.10",
@@ -175,15 +175,15 @@
 
     "@effect/language-service": ["@effect/language-service@0.80.0", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-dKMATT1fDzaCpNrICpXga7sjJBtFLpKCAoE/1MiGXI8UwcHA9rmAZ2t52JO9g/kJpERWyomkJ+rl+VFlwNIofg=="],
 
-    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-beta.34", "", { "dependencies": { "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^4.0.0-beta.34" } }, "sha512-2jmx00/rT/liNt7SMsUiZ2ZiQ6sv7jXIjWnZR4BQFO6DuR2CBH5vVKP1UoF/PLy+XHi93XX7o1JnLNI5ZrRwLQ=="],
+    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-beta.51", "", { "dependencies": { "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^4.0.0-beta.51" } }, "sha512-v7Zpjot3EvHSy4o+VNF/jGF2hxWCaCOdFmljJnweszrDHoTzu+mHGRYGN1CKLxOchwAuSnIDUwIVZ5Q6E0bBcA=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.34", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.34" }, "peerDependencies": { "effect": "^4.0.0-beta.34" } }, "sha512-5tkieXTPz5DZMjsv2tLJn5sE+xUHk60W4Okebr7ygpmv4VXp637von4ERqtJZRJIJZMETp8v/uezOKf12HzBuQ=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.51", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.51" }, "peerDependencies": { "effect": "^4.0.0-beta.51" } }, "sha512-jXLrwDvItGWWGljua80tBJyacvnDVBXueKbrOSWUStmwElIFH/mXtkG7lpwX+im5WSJeWaw5xidTW11HnCaGLA=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.34", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.34", "mime": "^4.1.0", "undici": "^7.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.34", "ioredis": "^5.7.0" } }, "sha512-zmFEJRhlHj+mkvekG3ZxXwhMfUZ05sn0WxGFQrVfNJmCGv9Cdi5zgbvl/W9JG/pO/RZsfzMY2hhGToXPWu1XWQ=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.51", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.51", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.51", "ioredis": "^5.7.0" } }, "sha512-ChkyABVJ35Eo2yQD3zSL6qvw9hTFZ/ikrGVoIm6rbAN3091XOs8hGMF8f1iyeUAXochjcTvz+tg+5jUNw7Ig8g=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.34", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.19.0" }, "peerDependencies": { "effect": "^4.0.0-beta.34" } }, "sha512-vq+36C2vWFS2iuYn2+9A93Kqrv6ehBy1FErFiBEotzeKSg4dByX8UUIG8kSwP3uBF/a+/Z4hHaSJD2zgCQFlsQ=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.51", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.51" } }, "sha512-Dy59kDf0UNiHImDN90edoNWbdpdbDqioVjjAPqKTOdebiVEHlD9bUSNTYsSnKrqa/6WU53AWOP0SYwJ1aKKk4Q=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.34", "", { "peerDependencies": { "effect": "^4.0.0-beta.34", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-HFQZDQLKAvzrT850/Hk2rXBp7OeIB4m10fd289Cd0kZ5xV0Szbr2rufw06Z29dRB3Cq3PWOHcC8Y6toWTi2oRw=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.51", "", { "peerDependencies": { "effect": "^4.0.0-beta.51", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-vRNwI8G3PdtVz+9cDmE8+KCbAp+2hGMa2ZSaqrb1yzBt0ZBltl1wLzRa9C5sf7Ite9B1euQpQN6+xEe+y2Gdqw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -735,7 +735,7 @@
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
-    "effect": ["effect@4.0.0-beta.34", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.5.3", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.8", "multipasta": "^0.2.7", "toml": "^3.0.0", "uuid": "^13.0.0", "yaml": "^2.8.2" } }, "sha512-NWSkkRLgn6g/UNPTS8Y52YYvjpfwGjH0iW9iWsoh63biAgg3IKq+FfEVZ4LzCNA5E7RPKNQFWa45JI10iJ9qdw=="],
+    "effect": ["effect@4.0.0-beta.51", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-Xo4MDGMhAAw/jPTT5zYk1H2FnllAVsSdZWLag+0yY4Hi1rksgReE2M4vFdqgl9wPV+30wVMvd95oPAczs71HIg=="],
 
     "effect-solutions": ["effect-solutions@workspace:packages/cli"],
 
@@ -1353,7 +1353,7 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
@@ -1371,7 +1371,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
+    "undici": ["undici@8.1.0", "", {}, "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -1439,7 +1439,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -1468,6 +1468,8 @@
     "@contentlayer/source-files/yaml": ["yaml@2.8.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
 
     "@contentlayer/utils/type-fest": ["type-fest@3.13.1", "", {}, "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="],
+
+    "@effect/platform-node-shared/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "@esbuild-plugins/node-resolve/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -1630,6 +1632,8 @@
     "remark-mdx-frontmatter/estree-util-is-identifier-name": ["estree-util-is-identifier-name@1.1.0", "", {}, "sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ=="],
 
     "remark-mdx-frontmatter/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "remark-mdx-frontmatter/toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,16 +9,16 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-visually-hidden": "^1.2.4",
         "cmdk": "^1.1.1",
-        "effect": "4.0.0-beta.52",
+        "effect": "4.0.0-beta.57",
         "ink": "^6.8.0",
         "next-mdx-remote": "^6.0.0",
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
-        "@effect/platform-bun": "4.0.0-beta.52",
-        "@effect/platform-node": "4.0.0-beta.52",
-        "@effect/vitest": "4.0.0-beta.52",
+        "@effect/platform-bun": "4.0.0-beta.57",
+        "@effect/platform-node": "4.0.0-beta.57",
+        "@effect/vitest": "4.0.0-beta.57",
         "vitest": "^4.1.0",
       },
     },
@@ -29,8 +29,8 @@
         "effect-solutions": "./bin.js",
       },
       "dependencies": {
-        "@effect/platform-bun": "beta",
-        "effect": "beta",
+        "@effect/platform-bun": "4.0.0-beta.57",
+        "effect": "4.0.0-beta.57",
         "gray-matter": "^4.0.3",
         "picocolors": "^1.1.1",
       },
@@ -45,11 +45,11 @@
       "name": "@effect-best-practices/website",
       "version": "0.5.2",
       "dependencies": {
-        "@effect/platform-browser": "4.0.0-beta.52",
+        "@effect/platform-browser": "4.0.0-beta.57",
         "@phosphor-icons/react": "^2.1.10",
         "@tailwindcss/typography": "^0.5.19",
         "@vercel/analytics": "^2.0.1",
-        "effect": "beta",
+        "effect": "4.0.0-beta.57",
         "motion": "^12.38.0",
         "next": "16.1.7",
         "overlayscrollbars": "^2.14.0",
@@ -60,7 +60,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.7",
-        "@effect/platform-bun": "beta",
+        "@effect/platform-bun": "4.0.0-beta.57",
         "@tailwindcss/postcss": "^4.2.1",
         "@types/hast": "^3.0.4",
         "@types/mdast": "^4.0.4",
@@ -175,15 +175,15 @@
 
     "@effect/language-service": ["@effect/language-service@0.80.0", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-dKMATT1fDzaCpNrICpXga7sjJBtFLpKCAoE/1MiGXI8UwcHA9rmAZ2t52JO9g/kJpERWyomkJ+rl+VFlwNIofg=="],
 
-    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-beta.52", "", { "dependencies": { "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^4.0.0-beta.52" } }, "sha512-/5JVgK3NqiRF/8sHhJnzc6QjPxRvsRoe7ZJkH1NitnUXNn0nZHFwTOOM8Vn1Wd1v2SUeOnWbMh3n/FuvvyEtKw=="],
+    "@effect/platform-browser": ["@effect/platform-browser@4.0.0-beta.57", "", { "dependencies": { "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^4.0.0-beta.57" } }, "sha512-bB/6ekUTc+fAympM36hiSROg6jjHLU5zNEpf07oXSqAnZnJL+wGix/8cmY/KPTTIobMXteq0suslrOY1cWZL8Q=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.52", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.52" }, "peerDependencies": { "effect": "^4.0.0-beta.52" } }, "sha512-Y1+2noV0Qt+tKL2oHQwm536SaPfig/hB0He45VdCphTUdz5OO9VcLZqLEfNRxFwttlJPWpOkm4HvKUQwcj/6TQ=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.57", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.57" }, "peerDependencies": { "effect": "^4.0.0-beta.57" } }, "sha512-Z/nG9KLUAPpd4UZXfjjz2giT0W/9iVItbVRJiQ8WReA6n5CEnBsrrE4ioRYOdamq/vRakxWBgqpG/4Mu6Ac7Hg=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.52", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.52", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.52", "ioredis": "^5.7.0" } }, "sha512-IFloMd95ot9SACJXPSVG060evsKSnGXlMqwQdyhSmsi7zMwiwbioItw1Up+EK5gJj7m3TRHO6b7fErqVgsN2kQ=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.57", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.57", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.57", "ioredis": "^5.7.0" } }, "sha512-la0xxPSAYOsY0d+uVxEBxok3jYB31iPQmIaZZRUj2SNWqcGGHJc6KorKtI8guqSLuv9FGZ255kBWXRbG6hMeeg=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.52", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.52" } }, "sha512-f4e0LD/VSlIWBRkjtaJ+zFDRZsdD4Fs3zPhvnkHn+N8qpAJ+HQ00oN5Zye7KJONPEI1JHUt2HwtbHeGCdnBFAw=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.57", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.57" } }, "sha512-C976X6f+qHUtLSqcqImuCrjhAHnJV17NC2RvvybsAuDfkyIWU4MyiO2XwgiBeijeNupyr1M/KPKnyjtkNxV9Hw=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.52", "", { "peerDependencies": { "effect": "^4.0.0-beta.52", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-xFHdZ9iwfbtfsqKEli0ZrowLijosWh3QUnVYvV3gxkWuU2oMfgG/FiA6jw9b2UkdqKA+X9uUFwBALVFK59ncKA=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.57", "", { "peerDependencies": { "effect": "^4.0.0-beta.57", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-XyGYv1zisrdP/N8+r4qaegyHZK4WS/1xBGlLPWqEoggBhgW7rD48cGUXDLEP7TlHcIJQiIlHtJlQUIwgVx3zWg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -735,7 +735,7 @@
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
-    "effect": ["effect@4.0.0-beta.52", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-Aa9T5CEV3pCoSDM8sOnalwYieJi5olb7vn8TbgMB3U1YGEOG9ypogng33qMFLKswZM2UimwrXL9Ri1x9Jo9z6w=="],
+    "effect": ["effect@4.0.0-beta.57", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-rg32VgXnLKaPRs9tbRDaZ5jxmzNY7ojXt85gSHGUTwdlbWH5Ik+OCUY2q14TXliygPGoHwCAvNWS4bQJOqf00g=="],
 
     "effect-solutions": ["effect-solutions@workspace:packages/cli"],
 

--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "cmdk": "^1.1.1",
-    "effect": "beta",
+    "effect": "4.0.0-beta.57",
     "ink": "^6.8.0",
     "next-mdx-remote": "^6.0.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
-    "@effect/platform-bun": "beta",
-    "@effect/platform-node": "beta",
-    "@effect/vitest": "beta",
+    "@effect/platform-bun": "4.0.0-beta.57",
+    "@effect/platform-node": "4.0.0-beta.57",
+    "@effect/vitest": "4.0.0-beta.57",
     "vitest": "^4.1.0"
   },
   "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,8 +29,8 @@
     "bun": ">=1.1.0"
   },
   "dependencies": {
-    "@effect/platform-bun": "beta",
-    "effect": "beta",
+    "@effect/platform-bun": "4.0.0-beta.57",
+    "effect": "4.0.0-beta.57",
     "gray-matter": "^4.0.3",
     "picocolors": "^1.1.1"
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 
-import { Argument, Command as CliCommand, Flag } from "effect/unstable/cli"
 import { BunRuntime, BunServices } from "@effect/platform-bun"
 import { Console, Effect, Layer, Option, pipe } from "effect"
+import { Argument, Command as CliCommand, Flag } from "effect/unstable/cli"
 import pc from "picocolors"
 import pkg from "../package.json" with { type: "json" }
 import { DOC_LOOKUP, DOCS } from "./docs-manifest"
@@ -133,10 +133,7 @@ const openIssueCommand = CliCommand.make("open-issue", {
     Flag.optional,
   ),
   title: Flag.string("title").pipe(Flag.withDescription("Brief issue title"), Flag.optional),
-  description: Flag.string("description").pipe(
-    Flag.withDescription("Detailed issue description"),
-    Flag.optional,
-  ),
+  description: Flag.string("description").pipe(Flag.withDescription("Detailed issue description"), Flag.optional),
 }).pipe(
   CliCommand.withDescription("Open a pre-filled GitHub issue in the effect-solutions repo"),
   CliCommand.withHandler(({ category, title, description }) =>

--- a/packages/cli/src/open-issue-service.ts
+++ b/packages/cli/src/open-issue-service.ts
@@ -1,15 +1,15 @@
 import { spawn } from "bun"
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 
 export const OpenIssueCategory = Schema.Literals(["Topic Request", "Fix", "Improvement"])
 export type OpenIssueCategory = typeof OpenIssueCategory.Type
 
-class BrowserOpenError extends Schema.TaggedErrorClass("BrowserOpenError")("BrowserOpenError", {
+class BrowserOpenError extends Schema.TaggedErrorClass<BrowserOpenError>()("BrowserOpenError", {
   url: Schema.String,
   cause: Schema.Defect,
 }) {}
 
-export class BrowserService extends ServiceMap.Service<
+export class BrowserService extends Context.Service<
   BrowserService,
   {
     readonly open: (url: string) => Effect.Effect<void, BrowserOpenError>
@@ -76,7 +76,7 @@ export type OpenIssueResult = {
   issueUrl: string
 }
 
-export class IssueService extends ServiceMap.Service<
+export class IssueService extends Context.Service<
   IssueService,
   {
     readonly open: (input: OpenIssueInput) => Effect.Effect<OpenIssueResult, BrowserOpenError>

--- a/packages/cli/src/update-notifier.ts
+++ b/packages/cli/src/update-notifier.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { Console, Effect, Layer, Option, Schema, ServiceMap } from "effect"
+import { Console, Context, Effect, Layer, Option, Schema } from "effect"
 
 const CacheFile = Schema.Struct({
   latest: Schema.String,
@@ -9,11 +9,11 @@ const CacheFile = Schema.Struct({
 })
 type CacheFile = typeof CacheFile.Type
 
-class UpdateCheckError extends Schema.TaggedErrorClass("UpdateCheckError")("UpdateCheckError", {
+class UpdateCheckError extends Schema.TaggedErrorClass<UpdateCheckError>()("UpdateCheckError", {
   cause: Schema.Defect,
 }) {}
 
-export class UpdateNotifier extends ServiceMap.Service<
+export class UpdateNotifier extends Context.Service<
   UpdateNotifier,
   {
     readonly check: (pkgName: string, currentVersion: string) => Effect.Effect<void, UpdateCheckError>
@@ -135,7 +135,7 @@ export class UpdateNotifier extends ServiceMap.Service<
   )
 }
 
-export class UpdateNotifierConfig extends ServiceMap.Service<
+export class UpdateNotifierConfig extends Context.Service<
   UpdateNotifierConfig,
   {
     readonly checkInterval: number

--- a/packages/website/docs/03-basics.md
+++ b/packages/website/docs/03-basics.md
@@ -91,7 +91,7 @@ declare const fetchData: Effect.Effect<string>
 
 const program = fetchData.pipe(
   Effect.timeout("5 seconds"),
-  Effect.retry(Schedule.exponential("100 millis").pipe(Schedule.compose(Schedule.recurs(3)))),
+  Effect.retry(Schedule.exponential("100 millis").pipe(Schedule.both(Schedule.recurs(3)))),
   Effect.tap((data) => Effect.logInfo(`Fetched: ${data}`)),
   Effect.withSpan("fetchData")
 )
@@ -116,7 +116,7 @@ declare const callExternalApi: Effect.Effect<string>
 
 // Retry with exponential backoff, max 3 attempts
 const retryPolicy = Schedule.exponential("100 millis").pipe(
-  Schedule.compose(Schedule.recurs(3))
+  Schedule.both(Schedule.recurs(3))
 )
 
 const resilientCall = callExternalApi.pipe(
@@ -134,4 +134,4 @@ const resilientCall = callExternalApi.pipe(
 - `Schedule.exponential` - exponential backoff
 - `Schedule.recurs` - limit number of retries
 - `Schedule.spaced` - fixed delay between retries
-- `Schedule.compose` - combine schedules (both must continue)
+- `Schedule.both` - combine schedules (both must continue)

--- a/packages/website/docs/04-services-and-layers.md
+++ b/packages/website/docs/04-services-and-layers.md
@@ -1,16 +1,16 @@
 ---
 title: Services & Layers
-description: "ServiceMap.Service and Layer patterns for dependency injection"
+description: "Context.Service and Layer patterns for dependency injection"
 order: 4
 ---
 
 # Services & Layers
 
-Effect's service pattern provides a deterministic way to organize your application through dependency injection. By defining services as `ServiceMap.Service` classes and composing them into Layers, you create explicit dependency graphs that are type-safe, testable, and modular.
+Effect's service pattern provides a deterministic way to organize your application through dependency injection. By defining services as `Context.Service` classes and composing them into Layers, you create explicit dependency graphs that are type-safe, testable, and modular.
 
 ## What is a Service?
 
-A service in Effect is defined using `ServiceMap.Service` as a class that declares:
+A service in Effect is defined using `Context.Service` as a class that declares:
 
 1. **A unique identifier** (e.g., `@app/Database`)
 2. **An interface** that describes the service's methods
@@ -18,9 +18,9 @@ A service in Effect is defined using `ServiceMap.Service` as a class that declar
 Services provide contracts without implementation. The actual behavior comes later through Layers.
 
 ```typescript
-import { Effect, ServiceMap } from "effect"
+import { Context, Effect } from "effect"
 
-class Database extends ServiceMap.Service<
+class Database extends Context.Service<
   Database,
   {
     readonly query: (sql: string) => Effect.Effect<unknown[]>
@@ -28,7 +28,7 @@ class Database extends ServiceMap.Service<
   }
 >()("@app/Database") {}
 
-class Logger extends ServiceMap.Service<
+class Logger extends Context.Service<
   Logger,
   {
     readonly log: (message: string) => Effect.Effect<void>
@@ -49,26 +49,26 @@ A Layer is an implementation of a service. Layers handle:
 3. **Resource lifecycle**: Cleanup happens automatically
 
 ```typescript
-import { HttpClient, HttpClientResponse } from "effect/unstable/http"
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { HttpClient, HttpClientError, HttpClientResponse } from "effect/unstable/http"
+import { Context, Effect, Layer, Schema } from "effect"
 
 const UserId = Schema.String.pipe(Schema.brand("UserId"))
 type UserId = typeof UserId.Type
 
-class User extends Schema.Class("User")({
+class User extends Schema.Class<User>("User")({
   id: UserId,
   name: Schema.String,
   email: Schema.String,
 }) {}
 
-class UserNotFoundError extends Schema.TaggedErrorClass("UserNotFoundError")(
+class UserNotFoundError extends Schema.TaggedErrorClass<UserNotFoundError>()(
   "UserNotFoundError",
   {
     id: UserId,
   }
 ) {}
 
-class GenericUsersError extends Schema.TaggedErrorClass("GenericUsersError")(
+class GenericUsersError extends Schema.TaggedErrorClass<GenericUsersError>()(
   "GenericUsersError",
   {
     id: UserId,
@@ -79,18 +79,18 @@ class GenericUsersError extends Schema.TaggedErrorClass("GenericUsersError")(
 const UsersError = Schema.Union([UserNotFoundError, GenericUsersError])
 type UsersError = typeof UsersError.Type
 
-class Analytics extends ServiceMap.Service<
+class Analytics extends Context.Service<
   Analytics,
   {
     readonly track: (event: string, data: Record<string, unknown>) => Effect.Effect<void>
   }
 >()("@app/Analytics") {}
 
-class Users extends ServiceMap.Service<
+class Users extends Context.Service<
   Users,
   {
-    readonly findById: (id: UserId) => Effect.Effect<User, UsersError>
-    readonly all: () => Effect.Effect<readonly User[]>
+    readonly findById: (id: UserId) => Effect.Effect<User, UsersError | Schema.SchemaError>
+    readonly all: () => Effect.Effect<readonly User[], HttpClientError.HttpClientError | Schema.SchemaError>
   }
 >()("@app/Users") {
   static readonly layer = Layer.effect(
@@ -102,15 +102,21 @@ class Users extends ServiceMap.Service<
 
       // 2. define the service methods with Effect.fn for call-site tracing
       const findById = Effect.fn("Users.findById")(
-        function* (id: UserId) {
+        (id: UserId): Effect.Effect<User, UsersError | Schema.SchemaError> =>
+        Effect.gen(function* () {
           yield* analytics.track("user.find", { id })
           const response = yield* http.get(`https://api.example.com/users/${id}`)
           return yield* HttpClientResponse.schemaBodyJson(User)(response)
-        },
-        Effect.catchTag("ResponseError", (error) =>
-          error.response.status === 404
-            ? new UserNotFoundError({ id })
-            : new GenericUsersError({ id, error }),
+        }).pipe(
+          Effect.catch((error): Effect.Effect<never, UsersError | Schema.SchemaError> => {
+            if (HttpClientError.isHttpClientError(error)) {
+              if (error.reason._tag === "StatusCodeError" && error.reason.response.status === 404) {
+                return Effect.fail(new UserNotFoundError({ id }))
+              }
+              return Effect.fail(new GenericUsersError({ id, error }))
+            }
+            return Effect.fail(error)
+          }),
         ),
       )
 
@@ -134,7 +140,7 @@ class Users extends ServiceMap.Service<
 Start by sketching leaf service tags (without implementations). This lets you write real TypeScript for higher-level orchestration services that type-checks even though the leaf services aren't runnable yet.
 
 ```typescript
-import { Clock, Effect, Layer, Schema, ServiceMap } from "effect"
+import { Clock, Context, Effect, Layer, Schema } from "effect"
 
 // Branded types for IDs
 const RegistrationId = Schema.String.pipe(Schema.brand("RegistrationId"))
@@ -150,13 +156,13 @@ const TicketId = Schema.String.pipe(Schema.brand("TicketId"))
 type TicketId = typeof TicketId.Type
 
 // Domain models
-class User extends Schema.Class("User")({
+class User extends Schema.Class<User>("User")({
   id: UserId,
   name: Schema.String,
   email: Schema.String,
 }) {}
 
-class Registration extends Schema.Class("Registration")({
+class Registration extends Schema.Class<Registration>("Registration")({
   id: RegistrationId,
   eventId: EventId,
   userId: UserId,
@@ -164,21 +170,21 @@ class Registration extends Schema.Class("Registration")({
   registeredAt: Schema.Date,
 }) {}
 
-class Ticket extends Schema.Class("Ticket")({
+class Ticket extends Schema.Class<Ticket>("Ticket")({
   id: TicketId,
   eventId: EventId,
   code: Schema.String,
 }) {}
 
 // Leaf services: contracts only
-class Users extends ServiceMap.Service<
+class Users extends Context.Service<
   Users,
   {
     readonly findById: (id: UserId) => Effect.Effect<User>
   }
 >()("@app/Users") {}
 
-class Tickets extends ServiceMap.Service<
+class Tickets extends Context.Service<
   Tickets,
   {
     readonly issue: (eventId: EventId, userId: UserId) => Effect.Effect<Ticket>
@@ -186,7 +192,7 @@ class Tickets extends ServiceMap.Service<
   }
 >()("@app/Tickets") {}
 
-class Emails extends ServiceMap.Service<
+class Emails extends Context.Service<
   Emails,
   {
     readonly send: (to: string, subject: string, body: string) => Effect.Effect<void>
@@ -194,7 +200,7 @@ class Emails extends ServiceMap.Service<
 >()("@app/Emails") {}
 
 // Higher-level service: orchestrates leaf services
-class Events extends ServiceMap.Service<
+class Events extends Context.Service<
   Events,
   {
     readonly register: (eventId: EventId, userId: UserId) => Effect.Effect<Registration>
@@ -214,7 +220,7 @@ class Events extends ServiceMap.Service<
           const now = yield* Clock.currentTimeMillis
 
           const registration = new Registration({
-            id: RegistrationId.makeUnsafe(crypto.randomUUID()),
+            id: RegistrationId.make(crypto.randomUUID()),
             eventId,
             userId,
             ticketId: ticket.id,
@@ -253,9 +259,9 @@ See [Testing with Vitest](./08-testing.md#worked-example-testing-a-service) for 
 When designing with services first, create lightweight test implementations. Use `Effect.sync` or `Effect.succeed` when your test doesn't need async operations or effects.
 
 ```typescript
-import { Console, Effect, Layer, ServiceMap } from "effect"
+import { Console, Context, Effect, Layer } from "effect"
 
-class Database extends ServiceMap.Service<
+class Database extends Context.Service<
   Database,
   {
     readonly query: (sql: string) => Effect.Effect<unknown[]>
@@ -275,7 +281,7 @@ class Database extends ServiceMap.Service<
   })
 }
 
-class Cache extends ServiceMap.Service<
+class Cache extends Context.Service<
   Cache,
   {
     readonly get: (key: string) => Effect.Effect<string | null>
@@ -298,12 +304,12 @@ class Cache extends ServiceMap.Service<
 Use `Effect.provide` once at the top of your application to supply all dependencies. Avoid scattering `provide` calls throughout your codebase.
 
 ```typescript
-import { Effect, Layer, ServiceMap } from "effect"
+import { Context, Effect, Layer } from "effect"
 // hide-start
-class Config extends ServiceMap.Service<Config, { readonly apiKey: string }>()("@app/Config") {}
-class Logger extends ServiceMap.Service<Logger, { readonly info: (msg: string) => Effect.Effect<void> }>()("@app/Logger") {}
-class Database extends ServiceMap.Service<Database, { readonly query: () => Effect.Effect<void> }>()("@app/Database") {}
-class UserService extends ServiceMap.Service<UserService, { readonly getUser: () => Effect.Effect<void> }>()("@app/UserService") {}
+class Config extends Context.Service<Config, { readonly apiKey: string }>()("@app/Config") {}
+class Logger extends Context.Service<Logger, { readonly info: (msg: string) => Effect.Effect<void> }>()("@app/Logger") {}
+class Database extends Context.Service<Database, { readonly query: () => Effect.Effect<void> }>()("@app/Database") {}
+class UserService extends Context.Service<UserService, { readonly getUser: () => Effect.Effect<void> }>()("@app/UserService") {}
 declare const configLayer: Layer.Layer<Config>
 declare const loggerLayer: Layer.Layer<Logger>
 declare const databaseLayer: Layer.Layer<Database>
@@ -347,13 +353,13 @@ This matters especially for resource-intensive layers like database connection p
 ```typescript
 import { Layer } from "effect"
 // hide-start
-import { Effect, ServiceMap } from "effect"
-class SqlClient extends ServiceMap.Service<SqlClient, { readonly query: (sql: string) => Effect.Effect<unknown[]> }>()("@app/SqlClient") {}
+import { Context, Effect } from "effect"
+class SqlClient extends Context.Service<SqlClient, { readonly query: (sql: string) => Effect.Effect<unknown[]> }>()("@app/SqlClient") {}
 class Postgres { static layer(_: { readonly url: string; readonly poolSize: number }): Layer.Layer<SqlClient> { return Layer.succeed(SqlClient, { query: () => Effect.succeed([]) }) } }
-class UserRepo extends ServiceMap.Service<UserRepo, {}>()("@app/UserRepo") {
+class UserRepo extends Context.Service<UserRepo, {}>()("@app/UserRepo") {
   static readonly layer: Layer.Layer<UserRepo, never, SqlClient> = Layer.succeed(UserRepo, {})
 }
-class OrderRepo extends ServiceMap.Service<OrderRepo, {}>()("@app/OrderRepo") {
+class OrderRepo extends Context.Service<OrderRepo, {}>()("@app/OrderRepo") {
   static readonly layer: Layer.Layer<OrderRepo, never, SqlClient> = Layer.succeed(OrderRepo, {})
 }
 // hide-end
@@ -375,13 +381,13 @@ const badAppLayer = Layer.merge(
 ```typescript
 import { Layer } from "effect"
 // hide-start
-import { Effect, ServiceMap } from "effect"
-class SqlClient extends ServiceMap.Service<SqlClient, { readonly query: (sql: string) => Effect.Effect<unknown[]> }>()("@app/SqlClient") {}
+import { Context, Effect } from "effect"
+class SqlClient extends Context.Service<SqlClient, { readonly query: (sql: string) => Effect.Effect<unknown[]> }>()("@app/SqlClient") {}
 class Postgres { static layer(_: { readonly url: string; readonly poolSize: number }): Layer.Layer<SqlClient> { return Layer.succeed(SqlClient, { query: () => Effect.succeed([]) }) } }
-class UserRepo extends ServiceMap.Service<UserRepo, {}>()("@app/UserRepo") {
+class UserRepo extends Context.Service<UserRepo, {}>()("@app/UserRepo") {
   static readonly layer: Layer.Layer<UserRepo, never, SqlClient> = Layer.succeed(UserRepo, {})
 }
-class OrderRepo extends ServiceMap.Service<OrderRepo, {}>()("@app/OrderRepo") {
+class OrderRepo extends Context.Service<OrderRepo, {}>()("@app/OrderRepo") {
   static readonly layer: Layer.Layer<OrderRepo, never, SqlClient> = Layer.succeed(OrderRepo, {})
 }
 // hide-end
@@ -402,7 +408,7 @@ const goodAppLayer = Layer.merge(
 
 Effect also provides [`Effect.Service`](https://effect.website/blog/releases/effect/39/#effectservice), which bundles a Tag and default Layer together. It's useful when you have an obvious default implementation.
 
-We focus on `ServiceMap.Service` here because it supports service-driven development: sketching interfaces before implementations. A future Effect version aims to combine both approaches.
+We focus on `Context.Service` here because it supports service-driven development: sketching interfaces before implementations.
 
 ## Sharing Layers Between Tests
 
@@ -414,9 +420,9 @@ Per-test layering (preferred):
 
 ```typescript
 import { expect, it } from "@effect/vitest"
-import { Effect, Layer, ServiceMap } from "effect"
+import { Context, Effect, Layer } from "effect"
 
-class Counter extends ServiceMap.Service<
+class Counter extends Context.Service<
   Counter,
   { readonly get: () => Effect.Effect<number>; readonly increment: () => Effect.Effect<void> }
 >()("@app/Counter") {
@@ -450,9 +456,9 @@ Suite-shared layering (only when you know you need it):
 
 ```typescript
 import { expect, it } from "@effect/vitest"
-import { Effect, Layer, ServiceMap } from "effect"
+import { Context, Effect, Layer } from "effect"
 
-class Counter extends ServiceMap.Service<
+class Counter extends Context.Service<
   Counter,
   {
     readonly get: () => Effect.Effect<number>

--- a/packages/website/docs/05-data-modeling.md
+++ b/packages/website/docs/05-data-modeling.md
@@ -36,7 +36,7 @@ import { Schema } from "effect"
 const UserId = Schema.String.pipe(Schema.brand("UserId"))
 type UserId = typeof UserId.Type
 
-export class User extends Schema.Class("User")({
+export class User extends Schema.Class<User>("User")({
   id: UserId,
   name: Schema.String,
   email: Schema.String,
@@ -50,7 +50,7 @@ export class User extends Schema.Class("User")({
 
 // Usage
 const user = new User({
-  id: UserId.makeUnsafe("user-123"),
+  id: UserId.make("user-123"),
   name: "Alice",
   email: "alice@example.com",
   createdAt: new Date(),
@@ -76,11 +76,11 @@ For structured variants with fields, combine `Schema.TaggedClass` with `Schema.U
 import { Match, Schema } from "effect"
 
 // Define variants with a tag field
-export class Success extends Schema.TaggedClass("Success")("Success", {
+export class Success extends Schema.TaggedClass<Success>("Success")("Success", {
   value: Schema.Number,
 }) {}
 
-export class Failure extends Schema.TaggedClass("Failure")("Failure", {
+export class Failure extends Schema.TaggedClass<Failure>("Failure")("Failure", {
   error: Schema.String,
 }) {}
 
@@ -88,15 +88,16 @@ export class Failure extends Schema.TaggedClass("Failure")("Failure", {
 export const Result = Schema.Union([Success, Failure])
 export type Result = typeof Result.Type
 
-// Pattern match with Match.valueTags
+// Pattern match with Match.value
 const success = new Success({ value: 42 })
 const failure = new Failure({ error: "oops" })
 
 const renderResult = (result: Result) =>
-  Match.valueTags(result, {
-    Success: ({ value }) => `Got: ${value}`,
-    Failure: ({ error }) => `Error: ${error}`,
-  })
+  Match.value(result).pipe(
+    Match.tag("Success", ({ value }) => `Got: ${value}`),
+    Match.tag("Failure", ({ error }) => `Error: ${error}`),
+    Match.exhaustive,
+  )
 
 renderResult(success) // "Got: 42"
 renderResult(failure) // "Error: oops"
@@ -130,9 +131,9 @@ export const Port = Schema.Int.pipe(Schema.check(Schema.isBetween({minimum: 1, m
 export type Port = typeof Port.Type
 
 // Usage - impossible to mix types
-const userId = UserId.makeUnsafe("user-123")
-const postId = PostId.makeUnsafe("post-456")
-const email = Email.makeUnsafe("alice@example.com")
+const userId = UserId.make("user-123")
+const postId = PostId.make("post-456")
+const email = Email.make("alice@example.com")
 
 function getUser(id: UserId) { return id }
 function sendEmail(to: Email) { return to }
@@ -157,12 +158,12 @@ import { Effect, Schema } from "effect"
 const Row = Schema.Literals(["A", "B", "C", "D", "E", "F", "G", "H"])
 const Column = Schema.Literals(["1", "2", "3", "4", "5", "6", "7", "8"])
 
-class Position extends Schema.Class("Position")({
+class Position extends Schema.Class<Position>("Position")({
   row: Row,
   column: Column,
 }) {}
 
-class Move extends Schema.Class("Move")({
+class Move extends Schema.Class<Move>("Move")({
   from: Position,
   to: Position,
 }) {}

--- a/packages/website/docs/06-error-handling.md
+++ b/packages/website/docs/06-error-handling.md
@@ -15,7 +15,7 @@ Define domain errors with `Schema.TaggedError`:
 ```typescript
 import { Schema } from "effect"
 
-class ValidationError extends Schema.TaggedErrorClass("ValidationError")(
+class ValidationError extends Schema.TaggedErrorClass<ValidationError>()(
   "ValidationError",
   {
     field: Schema.String,
@@ -23,7 +23,7 @@ class ValidationError extends Schema.TaggedErrorClass("ValidationError")(
   }
 ) {}
 
-class NotFoundError extends Schema.TaggedErrorClass("NotFoundError")(
+class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()(
   "NotFoundError",
   {
     resource: Schema.String,
@@ -54,7 +54,7 @@ const error = new ValidationError({
 ```typescript
 import { Effect, Random, Schema } from "effect"
 
-class BadLuck extends Schema.TaggedErrorClass("BadLuck")(
+class BadLuck extends Schema.TaggedErrorClass<BadLuck>()(
   "BadLuck",
   { roll: Schema.Number }
 ) {}
@@ -80,7 +80,7 @@ Handle all errors by providing a fallback effect:
 ```typescript
 import { Effect, Schema } from "effect"
 
-class HttpError extends Schema.TaggedErrorClass("HttpError")(
+class HttpError extends Schema.TaggedErrorClass<HttpError>()(
   "HttpError",
   {
     statusCode: Schema.Number,
@@ -88,7 +88,7 @@ class HttpError extends Schema.TaggedErrorClass("HttpError")(
   }
 ) {}
 
-class ValidationError extends Schema.TaggedErrorClass("ValidationError")(
+class ValidationError extends Schema.TaggedErrorClass<ValidationError>()(
   "ValidationError",
   {
     message: Schema.String,
@@ -101,7 +101,7 @@ const recovered: Effect.Effect<string, never> = program.pipe(
   Effect.catch((error) =>
     Effect.gen(function* () {
       yield* Effect.logError("Error occurred", error)
-      return `Recovered from ${error.name}`
+      return `Recovered from ${error._tag}`
     })
   )
 )
@@ -114,7 +114,7 @@ Handle specific errors by their `_tag`.
 ```typescript
 import { Effect, Schema } from "effect"
 
-class HttpError extends Schema.TaggedErrorClass("HttpError")(
+class HttpError extends Schema.TaggedErrorClass<HttpError>()(
   "HttpError",
   {
     statusCode: Schema.Number,
@@ -122,7 +122,7 @@ class HttpError extends Schema.TaggedErrorClass("HttpError")(
   }
 ) {}
 
-class ValidationError extends Schema.TaggedErrorClass("ValidationError")(
+class ValidationError extends Schema.TaggedErrorClass<ValidationError>()(
   "ValidationError",
   {
     message: Schema.String,
@@ -130,10 +130,10 @@ class ValidationError extends Schema.TaggedErrorClass("ValidationError")(
 ) {}
 
 const program: Effect.Effect<string, HttpError | ValidationError> =
-  new HttpError({
+  Effect.fail(new HttpError({
     statusCode: 500,
     message: "Internal server error",
-  })
+  }))
 
 const recovered: Effect.Effect<string, ValidationError> = program.pipe(
   Effect.catchTag("HttpError", (error) =>
@@ -152,7 +152,7 @@ Handle multiple error types at once.
 ```typescript
 import { Effect, Schema } from "effect"
 
-class HttpError extends Schema.TaggedErrorClass("HttpError")(
+class HttpError extends Schema.TaggedErrorClass<HttpError>()(
   "HttpError",
   {
     statusCode: Schema.Number,
@@ -160,7 +160,7 @@ class HttpError extends Schema.TaggedErrorClass("HttpError")(
   }
 ) {}
 
-class ValidationError extends Schema.TaggedErrorClass("ValidationError")(
+class ValidationError extends Schema.TaggedErrorClass<ValidationError>()(
   "ValidationError",
   {
     message: Schema.String,
@@ -168,10 +168,10 @@ class ValidationError extends Schema.TaggedErrorClass("ValidationError")(
 ) {}
 
 const program: Effect.Effect<string, HttpError | ValidationError> =
-  new HttpError({
+  Effect.fail(new HttpError({
     statusCode: 500,
     message: "Internal server error",
-  })
+  }))
 
 const recovered: Effect.Effect<string, never> = program.pipe(
   Effect.catchTags({
@@ -211,7 +211,7 @@ Use `Schema.Defect` to wrap unknown errors from external libraries.
 ```typescript
 import { Schema, Effect } from "effect"
 
-class ApiError extends Schema.TaggedErrorClass("ApiError")(
+class ApiError extends Schema.TaggedErrorClass<ApiError>()(
   "ApiError",
   {
     endpoint: Schema.String,

--- a/packages/website/docs/07-config.md
+++ b/packages/website/docs/07-config.md
@@ -67,9 +67,9 @@ Effect.runPromise(program.pipe(Effect.provide(testConfigLayer)))
 **Best practice:** Create a config service with a `layer` export:
 
 ```typescript
-import { Config, Effect, Layer, Redacted, ServiceMap } from "effect"
+import { Config, Context, Effect, Layer, Redacted } from "effect"
 
-class ApiConfig extends ServiceMap.Service<
+class ApiConfig extends Context.Service<
   ApiConfig,
   {
     readonly apiKey: Redacted.Redacted
@@ -113,7 +113,7 @@ class ApiConfig extends ServiceMap.Service<
 ## Config Primitives
 
 ```typescript
-import { Config } from "effect"
+import { Config, Schema } from "effect"
 
 // Strings
 Config.string("MY_VAR")
@@ -134,8 +134,8 @@ Config.url("API_URL")
 // Durations
 Config.duration("TIMEOUT")
 
-// Arrays (comma-separated values in env vars)
-Config.array(Config.string(), "TAGS")
+// Arrays (when the provider exposes an actual array node)
+Config.schema(Schema.Array(Schema.String), "TAGS")
 ```
 
 ## Defaults and Fallbacks
@@ -211,14 +211,14 @@ const program = Effect.gen(function* () {
 You can use `Config.mapOrFail` if you need custom validation without Schema:
 
 ```typescript
-import { Config, ConfigError, Effect } from "effect"
+import { Config, ConfigProvider, Effect } from "effect"
 
 const program = Effect.gen(function* () {
   const port = yield* Config.int("PORT").pipe(
     Config.mapOrFail((p) =>
       p > 0 && p < 65536
         ? Effect.succeed(p)
-        : Effect.fail(ConfigError.InvalidData([], "Port must be 1-65535"))
+        : Effect.fail(new Config.ConfigError(new ConfigProvider.SourceError({ message: "Port must be 1-65535" })))
     )
   )
 
@@ -233,7 +233,7 @@ Override where config is loaded from using `ConfigProvider.layer`:
 ```typescript
 import { ConfigProvider, Effect, Layer } from "effect"
 
-const program = Effect.unit
+const program = Effect.void
 
 const testConfigLayer = ConfigProvider.layer(
   ConfigProvider.fromUnknown({
@@ -243,7 +243,7 @@ const testConfigLayer = ConfigProvider.layer(
 )
 
 const jsonConfigLayer = ConfigProvider.layer(
-  ConfigProvider.fromJson({
+  ConfigProvider.fromUnknown({
     API_KEY: "prod-key",
     PORT: 8080,
   })
@@ -264,9 +264,9 @@ Effect.runPromise(program.pipe(Effect.provide(testConfigLayer)))
 **Best practice:** Just provide a layer with test values directly. No need for `ConfigProvider.fromMap`:
 
 ```typescript
-import { Config, Effect, Layer, Redacted, ServiceMap } from "effect"
+import { Config, Context, Effect, Layer, Redacted } from "effect"
 
-class ApiConfig extends ServiceMap.Service<
+class ApiConfig extends Context.Service<
   ApiConfig,
   {
     readonly apiKey: Redacted.Redacted
@@ -357,14 +357,14 @@ const program = Effect.gen(function* () {
 ## Example: Database Config Layer
 
 ```typescript
-import { Config, Effect, Layer, Redacted, Schema, ServiceMap } from "effect"
+import { Config, Context, Effect, Layer, Redacted, Schema } from "effect"
 
 const Port = Schema.NumberFromString.pipe(
   Schema.check(Schema.isInt()),
   Schema.check(Schema.isBetween({minimum: 1, maximum: 65535}))
 )
 
-class DatabaseConfig extends ServiceMap.Service<
+class DatabaseConfig extends Context.Service<
   DatabaseConfig,
   {
     readonly host: string

--- a/packages/website/docs/07-config.md
+++ b/packages/website/docs/07-config.md
@@ -134,7 +134,17 @@ Config.url("API_URL")
 // Durations
 Config.duration("TIMEOUT")
 
-// Arrays (when the provider exposes an actual array node)
+// Env vars are strings, so parse comma-separated values yourself
+Config.string("TAGS").pipe(
+  Config.map((value) =>
+    value
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0)
+  )
+)
+
+// Structured providers can expose actual arrays
 Config.schema(Schema.Array(Schema.String), "TAGS")
 ```
 

--- a/packages/website/docs/08-testing.md
+++ b/packages/website/docs/08-testing.md
@@ -167,9 +167,9 @@ it.effect("time-based test", () =>
 Use `Effect.provide()` inline for test-specific layers:
 
 ```typescript
-import { Effect, Layer, ServiceMap } from "effect"
+import { Context, Effect, Layer } from "effect"
 
-class Database extends ServiceMap.Service<
+class Database extends Context.Service<
   Database,
   { query: (sql: string) => Effect.Effect<string[]> }
 >()("Database") {}
@@ -237,7 +237,7 @@ import { Effect, Logger } from "effect"
 it.effect("with logging", () =>
   Effect.gen(function* () {
     yield* Effect.log("This will be shown")
-  }).pipe(Effect.provide(Logger.pretty))
+  }).pipe(Effect.provide(Logger.layer([Logger.consolePretty()])))
 )
 
 // Option 2: Use it.live (logging enabled by default)
@@ -255,7 +255,7 @@ Here's a complete example testing the `Events` service from the [Services & Laye
 First, define domain types and services with test layers built-in:
 
 ```typescript
-import { Clock, Effect, Layer, Option, Schema, ServiceMap } from "effect"
+import { Clock, Context, Effect, Layer, Option, Schema } from "effect"
 import { describe, expect, it } from "@effect/vitest"
 
 // Domain types
@@ -271,13 +271,13 @@ type UserId = typeof UserId.Type
 const TicketId = Schema.String.pipe(Schema.brand("TicketId"))
 type TicketId = typeof TicketId.Type
 
-class User extends Schema.Class("User")({
+class User extends Schema.Class<User>("User")({
   id: UserId,
   name: Schema.String,
   email: Schema.String,
 }) {}
 
-class Registration extends Schema.Class("Registration")({
+class Registration extends Schema.Class<Registration>("Registration")({
   id: RegistrationId,
   eventId: EventId,
   userId: UserId,
@@ -285,24 +285,24 @@ class Registration extends Schema.Class("Registration")({
   registeredAt: Schema.Date,
 }) {}
 
-class Ticket extends Schema.Class("Ticket")({
+class Ticket extends Schema.Class<Ticket>("Ticket")({
   id: TicketId,
   eventId: EventId,
   code: Schema.String,
 }) {}
 
-class Email extends Schema.Class("Email")({
+class Email extends Schema.Class<Email>("Email")({
   to: Schema.String,
   subject: Schema.String,
   body: Schema.String,
 }) {}
 
-class UserNotFound extends Schema.TaggedErrorClass("UserNotFound")("UserNotFound", {
+class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()("UserNotFound", {
   id: UserId,
 }) {}
 
 // Users service with test layer that has create + findById
-class Users extends ServiceMap.Service<
+class Users extends Context.Service<
   Users,
   {
     readonly create: (user: User) => Effect.Effect<void>
@@ -326,7 +326,7 @@ class Users extends ServiceMap.Service<
 }
 
 // Tickets service with test layer
-class Tickets extends ServiceMap.Service<
+class Tickets extends Context.Service<
   Tickets,
   { readonly issue: (eventId: EventId, userId: UserId) => Effect.Effect<Ticket> }
 >()("@app/Tickets") {
@@ -336,7 +336,7 @@ class Tickets extends ServiceMap.Service<
     const issue = (eventId: EventId, _userId: UserId) =>
       Effect.sync(() =>
         new Ticket({
-          id: TicketId.makeUnsafe(`ticket-${counter++}`),
+          id: TicketId.make(`ticket-${counter++}`),
           eventId,
           code: `CODE-${counter}`,
         })
@@ -347,7 +347,7 @@ class Tickets extends ServiceMap.Service<
 }
 
 // Emails service with test layer that tracks sent emails
-class Emails extends ServiceMap.Service<
+class Emails extends Context.Service<
   Emails,
   {
     readonly send: (email: Email) => Effect.Effect<void>
@@ -369,7 +369,26 @@ class Emails extends ServiceMap.Service<
 The Events service orchestrates the leaf services:
 
 ```typescript
-class Events extends ServiceMap.Service<
+import { Clock, Context, Effect, Layer, Schema } from "effect"
+// hide-start
+const RegistrationId = Schema.String.pipe(Schema.brand("RegistrationId"))
+type RegistrationId = typeof RegistrationId.Type
+const EventId = Schema.String.pipe(Schema.brand("EventId"))
+type EventId = typeof EventId.Type
+const UserId = Schema.String.pipe(Schema.brand("UserId"))
+type UserId = typeof UserId.Type
+const TicketId = Schema.String.pipe(Schema.brand("TicketId"))
+type TicketId = typeof TicketId.Type
+class User extends Schema.Class<User>("User")({ id: UserId, name: Schema.String, email: Schema.String }) {}
+class Registration extends Schema.Class<Registration>("Registration")({ id: RegistrationId, eventId: EventId, userId: UserId, ticketId: TicketId, registeredAt: Schema.Date }) {}
+class Ticket extends Schema.Class<Ticket>("Ticket")({ id: TicketId, eventId: EventId, code: Schema.String }) {}
+class Email extends Schema.Class<Email>("Email")({ to: Schema.String, subject: Schema.String, body: Schema.String }) {}
+class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()("UserNotFound", { id: UserId }) {}
+class Users extends Context.Service<Users, { readonly findById: (id: UserId) => Effect.Effect<User, UserNotFound> }>()("@app/Users") {}
+class Tickets extends Context.Service<Tickets, { readonly issue: (eventId: EventId, userId: UserId) => Effect.Effect<Ticket> }>()("@app/Tickets") {}
+class Emails extends Context.Service<Emails, { readonly send: (email: Email) => Effect.Effect<void> }>()("@app/Emails") {}
+// hide-end
+class Events extends Context.Service<
   Events,
   { readonly register: (eventId: EventId, userId: UserId) => Effect.Effect<Registration, UserNotFound> }
 >()("@app/Events") {
@@ -387,7 +406,7 @@ class Events extends ServiceMap.Service<
           const now = yield* Clock.currentTimeMillis
 
           const registration = new Registration({
-            id: RegistrationId.makeUnsafe(crypto.randomUUID()),
+            id: RegistrationId.make(crypto.randomUUID()),
             eventId,
             userId,
             ticketId: ticket.id,
@@ -415,6 +434,82 @@ class Events extends ServiceMap.Service<
 Compose test layers and write tests:
 
 ```typescript
+import { describe, expect, it } from "@effect/vitest"
+import { Clock, Context, Effect, Layer, Option, Schema } from "effect"
+// hide-start
+const RegistrationId = Schema.String.pipe(Schema.brand("RegistrationId"))
+type RegistrationId = typeof RegistrationId.Type
+const EventId = Schema.String.pipe(Schema.brand("EventId"))
+type EventId = typeof EventId.Type
+const UserId = Schema.String.pipe(Schema.brand("UserId"))
+type UserId = typeof UserId.Type
+const TicketId = Schema.String.pipe(Schema.brand("TicketId"))
+type TicketId = typeof TicketId.Type
+class User extends Schema.Class<User>("User")({ id: UserId, name: Schema.String, email: Schema.String }) {}
+class Registration extends Schema.Class<Registration>("Registration")({ id: RegistrationId, eventId: EventId, userId: UserId, ticketId: TicketId, registeredAt: Schema.Date }) {}
+class Ticket extends Schema.Class<Ticket>("Ticket")({ id: TicketId, eventId: EventId, code: Schema.String }) {}
+class Email extends Schema.Class<Email>("Email")({ to: Schema.String, subject: Schema.String, body: Schema.String }) {}
+class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()("UserNotFound", { id: UserId }) {}
+class Users extends Context.Service<Users, { readonly create: (user: User) => Effect.Effect<void>; readonly findById: (id: UserId) => Effect.Effect<User, UserNotFound> }>()("@app/Users") {
+  static readonly testLayer = Layer.sync(Users, () => {
+    const store = new Map<UserId, User>()
+    return {
+      create: (user: User) => Effect.sync(() => void store.set(user.id, user)),
+      findById: (id: UserId) =>
+        Option.fromNullishOr(store.get(id)).pipe(
+          Effect.fromOption,
+          Effect.catch(() => Effect.fail(new UserNotFound({ id }))),
+        ),
+    }
+  })
+}
+class Tickets extends Context.Service<Tickets, { readonly issue: (eventId: EventId, userId: UserId) => Effect.Effect<Ticket> }>()("@app/Tickets") {
+  static readonly testLayer = Layer.sync(Tickets, () => ({
+    issue: (eventId: EventId, _userId: UserId) =>
+      Effect.sync(() => new Ticket({ id: TicketId.make("ticket-0"), eventId, code: "CODE-1" })),
+  }))
+}
+class Emails extends Context.Service<Emails, { readonly send: (email: Email) => Effect.Effect<void>; readonly sent: Effect.Effect<ReadonlyArray<Email>> }>()("@app/Emails") {
+  static readonly testLayer = Layer.sync(Emails, () => {
+    const emails: Array<Email> = []
+    return {
+      send: (email: Email) => Effect.sync(() => void emails.push(email)),
+      sent: Effect.sync(() => emails),
+    }
+  })
+}
+class Events extends Context.Service<Events, { readonly register: (eventId: EventId, userId: UserId) => Effect.Effect<Registration, UserNotFound> }>()("@app/Events") {
+  static readonly layer = Layer.effect(
+    Events,
+    Effect.gen(function* () {
+      const users = yield* Users
+      const tickets = yield* Tickets
+      const emails = yield* Emails
+      const register = Effect.fn("Events.register")(function* (eventId: EventId, userId: UserId) {
+        const user = yield* users.findById(userId)
+        const ticket = yield* tickets.issue(eventId, userId)
+        const now = yield* Clock.currentTimeMillis
+        const registration = new Registration({
+          id: RegistrationId.make(crypto.randomUUID()),
+          eventId,
+          userId,
+          ticketId: ticket.id,
+          registeredAt: new Date(now),
+        })
+        yield* emails.send(
+          new Email({
+            to: user.email,
+            subject: "Event Registration Confirmed",
+            body: `Your ticket code: ${ticket.code}`,
+          }),
+        )
+        return registration
+      })
+      return { register }
+    }),
+  )
+}
+// hide-end
 // provideMerge exposes leaf services in tests for setup/assertions
 const testLayer = Events.layer.pipe(
   Layer.provideMerge(Users.testLayer),
@@ -430,14 +525,14 @@ describe("Events.register", () => {
 
       // Arrange: create a user
       const user = new User({
-        id: UserId.makeUnsafe("user-123"),
+        id: UserId.make("user-123"),
         name: "Alice",
         email: "alice@example.com",
       })
       yield* users.create(user)
 
       // Act
-      const eventId = EventId.makeUnsafe("event-789")
+      const eventId = EventId.make("event-789")
       const registration = yield* events.register(eventId, user.id)
 
       // Assert
@@ -454,21 +549,22 @@ describe("Events.register", () => {
 
       // Arrange
       const user = new User({
-        id: UserId.makeUnsafe("user-456"),
+        id: UserId.make("user-456"),
         name: "Bob",
         email: "bob@example.com",
       })
       yield* users.create(user)
 
       // Act
-      yield* events.register(EventId.makeUnsafe("event-789"), user.id)
+      yield* events.register(EventId.make("event-789"), user.id)
 
       // Assert: check sent emails
       const sentEmails = yield* emails.sent
+      const firstEmail = sentEmails[0]!
       expect(sentEmails).toHaveLength(1)
-      expect(sentEmails[0].to).toBe("bob@example.com")
-      expect(sentEmails[0].subject).toBe("Event Registration Confirmed")
-      expect(sentEmails[0].body).toContain("CODE-")
+      expect(firstEmail.to).toBe("bob@example.com")
+      expect(firstEmail.subject).toBe("Event Registration Confirmed")
+      expect(firstEmail.body).toContain("CODE-")
     }).pipe(Effect.provide(testLayer))
   )
 })

--- a/packages/website/docs/11-http-clients.md
+++ b/packages/website/docs/11-http-clients.md
@@ -209,14 +209,14 @@ type UserId = typeof UserId.Type
 const RepoId = Schema.Number.pipe(Schema.brand("RepoId"))
 type RepoId = typeof RepoId.Type
 
-class User extends Schema.Class("User")({
+class User extends Schema.Class<User>("User")({
   id: UserId,
   login: Schema.String,
   name: Schema.NullOr(Schema.String),
   public_repos: Schema.Number,
 }) {}
 
-class Repo extends Schema.Class("Repo")({
+class Repo extends Schema.Class<Repo>("Repo")({
   id: RepoId,
   name: Schema.String,
   full_name: Schema.String,
@@ -229,7 +229,7 @@ class Repo extends Schema.Class("Repo")({
 
 ```typescript
 import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 
 // hide-start
 const UserId = Schema.Number.pipe(Schema.brand("UserId"))
@@ -238,14 +238,14 @@ type UserId = typeof UserId.Type
 const RepoId = Schema.Number.pipe(Schema.brand("RepoId"))
 type RepoId = typeof RepoId.Type
 
-class User extends Schema.Class("User")({
+class User extends Schema.Class<User>("User")({
   id: UserId,
   login: Schema.String,
   name: Schema.NullOr(Schema.String),
   public_repos: Schema.Number,
 }) {}
 
-class Repo extends Schema.Class("Repo")({
+class Repo extends Schema.Class<Repo>("Repo")({
   id: RepoId,
   name: Schema.String,
   full_name: Schema.String,
@@ -254,12 +254,12 @@ class Repo extends Schema.Class("Repo")({
 }) {}
 // hide-end
 
-class GitHubApi extends ServiceMap.Service<
+class GitHubApi extends Context.Service<
   GitHubApi,
   {
-    readonly getUser: (username: string) => Effect.Effect<User>
-    readonly getRepo: (owner: string, repo: string) => Effect.Effect<Repo>
-    readonly listRepos: (username: string) => Effect.Effect<ReadonlyArray<Repo>>
+    readonly getUser: (username: string) => Effect.Effect<User, unknown>
+    readonly getRepo: (owner: string, repo: string) => Effect.Effect<Repo, unknown>
+    readonly listRepos: (username: string) => Effect.Effect<ReadonlyArray<Repo>, unknown>
   }
 >()("GitHubApi") {
   static layer = Layer.effect(
@@ -297,7 +297,7 @@ class GitHubApi extends ServiceMap.Service<
 
 ```typescript
 import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 
 // hide-start
 const UserId = Schema.Number.pipe(Schema.brand("UserId"))
@@ -306,14 +306,14 @@ type UserId = typeof UserId.Type
 const RepoId = Schema.Number.pipe(Schema.brand("RepoId"))
 type RepoId = typeof RepoId.Type
 
-class User extends Schema.Class("User")({
+class User extends Schema.Class<User>("User")({
   id: UserId,
   login: Schema.String,
   name: Schema.NullOr(Schema.String),
   public_repos: Schema.Number,
 }) {}
 
-class Repo extends Schema.Class("Repo")({
+class Repo extends Schema.Class<Repo>("Repo")({
   id: RepoId,
   name: Schema.String,
   full_name: Schema.String,
@@ -321,12 +321,12 @@ class Repo extends Schema.Class("Repo")({
   language: Schema.NullOr(Schema.String),
 }) {}
 
-class GitHubApi extends ServiceMap.Service<
+class GitHubApi extends Context.Service<
   GitHubApi,
   {
-    readonly getUser: (username: string) => Effect.Effect<User>
-    readonly getRepo: (owner: string, repo: string) => Effect.Effect<Repo>
-    readonly listRepos: (username: string) => Effect.Effect<ReadonlyArray<Repo>>
+    readonly getUser: (username: string) => Effect.Effect<User, unknown>
+    readonly getRepo: (owner: string, repo: string) => Effect.Effect<Repo, unknown>
+    readonly listRepos: (username: string) => Effect.Effect<ReadonlyArray<Repo>, unknown>
   }
 >()("GitHubApi") {
   static layer = Layer.effect(
@@ -450,7 +450,7 @@ const getRepoWithRetry = Effect.gen(function* () {
   const response = yield* HttpClient.get("https://api.github.com/repos/Effect-TS/effect")
   return yield* HttpClientResponse.schemaBodyJson(Repo)(response)
 }).pipe(
-  Effect.retry(Schedule.exponential("100 millis").pipe(Schedule.compose(Schedule.recurs(3))))
+  Effect.retry(Schedule.exponential("100 millis").pipe(Schedule.both(Schedule.recurs(3))))
 )
 
 getRepoWithRetry.pipe(Effect.provide(FetchHttpClient.layer), Effect.runPromise)

--- a/packages/website/docs/13-cli.md
+++ b/packages/website/docs/13-cli.md
@@ -34,12 +34,11 @@ const greet = Command.make("greet", { name, shout }, ({ name, shout }) => {
   return Console.log(shout ? message.toUpperCase() : message)
 })
 
-const cli = Command.run(greet, {
-  name: "greet",
+const program = Command.run(greet, {
   version: "1.0.0"
 })
 
-cli(process.argv).pipe(
+program.pipe(
   Effect.provide(BunServices.layer),
   BunRuntime.runMain
 )
@@ -155,7 +154,7 @@ import { Array, Option, Schema } from "effect"
 const TaskId = Schema.Number.pipe(Schema.brand("TaskId"))
 type TaskId = typeof TaskId.Type
 
-class Task extends Schema.Class("Task")({
+class Task extends Schema.Class<Task>("Task")({
   id: TaskId,
   text: Schema.NonEmptyString,
   done: Schema.Boolean
@@ -165,15 +164,15 @@ class Task extends Schema.Class("Task")({
   }
 }
 
-class TaskList extends Schema.Class("TaskList")({
+class TaskList extends Schema.Class<TaskList>("TaskList")({
   tasks: Schema.Array(Task)
 }) {
   static Json = Schema.fromJsonString(TaskList)
   static empty = new TaskList({ tasks: [] })
 
   get nextId(): TaskId {
-    if (this.tasks.length === 0) return TaskId.makeUnsafe(1)
-    return TaskId.makeUnsafe(Math.max(...this.tasks.map((t) => t.id)) + 1)
+    if (this.tasks.length === 0) return TaskId.make(1)
+    return TaskId.make(Math.max(...this.tasks.map((t) => t.id)) + 1)
   }
 
   add(text: string): [TaskList, Task] {
@@ -185,8 +184,9 @@ class TaskList extends Schema.Class("TaskList")({
     const index = this.tasks.findIndex((t) => t.id === id)
     if (index === -1) return [this, Option.none()]
 
-    const updated = this.tasks[index].toggle()
-    const tasks = Array.modify(this.tasks, index, () => updated)
+    const updated = this.tasks[index]!.toggle()
+    const tasks = [...this.tasks]
+    tasks[index] = updated
     return [new TaskList({ tasks }), Option.some(updated)]
   }
 
@@ -207,12 +207,12 @@ class TaskList extends Schema.Class("TaskList")({
 ### The TaskRepo Service
 
 ```typescript
-import { Array, Effect, FileSystem, Layer, Option, Schema, ServiceMap } from "effect"
+import { Array, Context, Effect, FileSystem, Layer, Option, Schema } from "effect"
 // hide-start
 const TaskId = Schema.Number.pipe(Schema.brand("TaskId"))
 type TaskId = typeof TaskId.Type
 
-class Task extends Schema.Class("Task")({
+class Task extends Schema.Class<Task>("Task")({
   id: TaskId,
   text: Schema.NonEmptyString,
   done: Schema.Boolean
@@ -222,7 +222,7 @@ class Task extends Schema.Class("Task")({
   }
 }
 
-class TaskList extends Schema.Class("TaskList")({
+class TaskList extends Schema.Class<TaskList>("TaskList")({
   tasks: Schema.Array(Task)
 }) {
   static Json = Schema.fromJsonString(TaskList)
@@ -237,25 +237,26 @@ class TaskList extends Schema.Class("TaskList")({
     const index = this.tasks.findIndex((t) => t.id === id)
     if (index === -1) return [this, Option.none()]
     const updated = this.tasks[index]!.toggle()
-    const tasks = Array.modify(this.tasks, index, () => updated)
+    const tasks = [...this.tasks]
+    tasks[index] = updated
     return [new TaskList({ tasks }), Option.some(updated)]
   }
 
   get nextId(): TaskId {
-    if (this.tasks.length === 0) return TaskId.makeUnsafe(1)
-    return TaskId.makeUnsafe(Math.max(...this.tasks.map((t) => t.id)) + 1)
+    if (this.tasks.length === 0) return TaskId.make(1)
+    return TaskId.make(Math.max(...this.tasks.map((t) => t.id)) + 1)
   }
 }
 
 // hide-end
 
-class TaskRepo extends ServiceMap.Service<
+class TaskRepo extends Context.Service<
   TaskRepo,
   {
-    readonly list: (all?: boolean) => Effect.Effect<ReadonlyArray<Task>>
-    readonly add: (text: string) => Effect.Effect<Task>
-    readonly toggle: (id: TaskId) => Effect.Effect<Option.Option<Task>>
-    readonly clear: () => Effect.Effect<void>
+    readonly list: (all?: boolean) => Effect.Effect<ReadonlyArray<Task>, unknown>
+    readonly add: (text: string) => Effect.Effect<Task, unknown>
+    readonly toggle: (id: TaskId) => Effect.Effect<Option.Option<Task>, unknown>
+    readonly clear: () => Effect.Effect<void, unknown>
   }
 >()("TaskRepo") {
   static layer = Layer.effect(
@@ -311,7 +312,7 @@ class TaskRepo extends ServiceMap.Service<
 
 ```typescript
 import { Argument, Command, Flag } from "effect/unstable/cli"
-import { Console, Effect, Option, Schema, ServiceMap } from "effect"
+import { Console, Context, Effect, Option, Schema } from "effect"
 
 // hide-start
 // Minimal stubs to keep this example self-contained for typechecking
@@ -319,7 +320,7 @@ const TaskId = Schema.Number.pipe(Schema.brand("TaskId"))
 type TaskId = typeof TaskId.Type
 type Task = { id: number; text: string; done: boolean }
 
-class TaskRepo extends ServiceMap.Service<
+class TaskRepo extends Context.Service<
   TaskRepo,
   {
     readonly add: (text: string) => Effect.Effect<Task>
@@ -403,15 +404,23 @@ const app = Command.make("tasks", {}).pipe(
 
 ```typescript
 import { BunServices, BunRuntime } from "@effect/platform-bun"
+import { Command } from "effect/unstable/cli"
+import { Context, Effect, Layer } from "effect"
 
-const cli = Command.run(app, {
-  name: "tasks",
+// hide-start
+const app = Command.make("tasks")
+class TaskRepo extends Context.Service<TaskRepo, { readonly clear: () => Effect.Effect<void> }>()("TaskRepo") {
+  static readonly layer = Layer.succeed(TaskRepo, { clear: () => Effect.void })
+}
+// hide-end
+
+const program = Command.run(app, {
   version: "1.0.0"
 })
 
-const mainLayer = Layer.provideMerge(TaskRepo.layer, BunServices.layer)
+const mainLayer = Layer.merge(TaskRepo.layer, BunServices.layer)
 
-cli(process.argv).pipe(Effect.provide(mainLayer), BunRuntime.runMain)
+program.pipe(Effect.provide(mainLayer), BunRuntime.runMain)
 ```
 
 ### Using the CLI
@@ -463,7 +472,7 @@ The tasks persist to `tasks.json`:
 | Flag alias | `Flag.withAlias("v")` |
 | Descriptions | `Argument.withDescription`, `Flag.withDescription`, `Command.withDescription` |
 | Subcommands | `Command.withSubcommands([...])` |
-| Run CLI | `Command.run(cmd, { name, version })` |
+| Run CLI | `Command.run(cmd, { version })` |
 | Platform layer | `BunServices.layer` or `NodeServices.layer` |
 
 For the full API, see the [Effect CLI documentation](https://effect-ts.github.io/effect/docs/cli).
@@ -475,6 +484,7 @@ For the full API, see the [Effect CLI documentation](https://effect-ts.github.io
 Import your version from `package.json` to keep it in sync with your published package:
 
 ```typescript
+// typecheck:skip
 import { Command } from "effect/unstable/cli"
 import pkg from "./package.json" with { type: "json" }
 
@@ -483,7 +493,6 @@ const app = Command.make("tasks")
 // hide-end
 
 const cli = Command.run(app, {
-  name: "tasks",
   version: pkg.version
 })
 ```

--- a/packages/website/docs/14-use-pattern.md
+++ b/packages/website/docs/14-use-pattern.md
@@ -24,15 +24,15 @@ For libraries with only a few methods, consider wrapping each method individuall
 ## The pattern
 
 ```typescript
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 import * as fs_ from "node:fs/promises"
 
-class FileSystemError extends Schema.TaggedErrorClass("FileSystemError")(
+class FileSystemError extends Schema.TaggedErrorClass<FileSystemError>()(
   "FileSystemError",
   { cause: Schema.optional(Schema.Unknown) }
 ) {}
 
-class FileSystem extends ServiceMap.Service<FileSystem, {
+class FileSystem extends Context.Service<FileSystem, {
   readonly use: <A>(
     fn: (fs: typeof fs_, signal: AbortSignal) => Promise<A>
   ) => Effect.Effect<A, FileSystemError>
@@ -65,13 +65,13 @@ The service exposes a single `use` method that:
 ```typescript
 import { Effect, pipe } from "effect"
 // hide-start
-import { Layer, Schema, ServiceMap } from "effect"
+import { Context, Layer, Schema } from "effect"
 import * as fs_ from "node:fs/promises"
-class FileSystemError extends Schema.TaggedErrorClass("FileSystemError")(
+class FileSystemError extends Schema.TaggedErrorClass<FileSystemError>()(
   "FileSystemError",
   { cause: Schema.optional(Schema.Unknown) }
 ) {}
-class FileSystem extends ServiceMap.Service<FileSystem, {
+class FileSystem extends Context.Service<FileSystem, {
   readonly use: <A>(fn: (fs: typeof fs_, signal: AbortSignal) => Promise<A>) => Effect.Effect<A, FileSystemError>
 }>()("FileSystem") {
   static readonly Default = Layer.effect(FileSystem, Effect.succeed({
@@ -120,15 +120,15 @@ When the Effect is interrupted, the signal is aborted, allowing operations that 
 For frequently used operations, add typed methods alongside `use`:
 
 ```typescript
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 import * as fs_ from "node:fs/promises"
 
-class FileSystemError extends Schema.TaggedErrorClass("FileSystemError")(
+class FileSystemError extends Schema.TaggedErrorClass<FileSystemError>()(
   "FileSystemError",
   { cause: Schema.optional(Schema.Unknown) }
 ) {}
 
-class FileSystem extends ServiceMap.Service<FileSystem, {
+class FileSystem extends Context.Service<FileSystem, {
   readonly use: <A>(fn: (fs: typeof fs_, signal: AbortSignal) => Promise<A>) => Effect.Effect<A, FileSystemError>
   readonly readFile: (path: string) => Effect.Effect<string, FileSystemError>
   readonly writeFile: (path: string, content: string) => Effect.Effect<void, FileSystemError>
@@ -177,15 +177,15 @@ You could expose the underlying client directly, but the callback approach provi
 If you prefer direct access, you can expose both:
 
 ```typescript
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 import * as fs_ from "node:fs/promises"
 
-class FileSystemError extends Schema.TaggedErrorClass("FileSystemError")(
+class FileSystemError extends Schema.TaggedErrorClass<FileSystemError>()(
   "FileSystemError",
   { cause: Schema.optional(Schema.Unknown) }
 ) {}
 
-class FileSystem extends ServiceMap.Service<FileSystem, {
+class FileSystem extends Context.Service<FileSystem, {
   readonly client: typeof fs_
   readonly use: <A>(fn: (fs: typeof fs_, signal: AbortSignal) => Promise<A>) => Effect.Effect<A, FileSystemError>
 }>()("FileSystem") {
@@ -214,15 +214,15 @@ The trade-off is direct client access loses automatic error wrapping and interru
 Create a test layer that uses in-memory storage:
 
 ```typescript
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 import * as fs_ from "node:fs/promises"
 
-class FileSystemError extends Schema.TaggedErrorClass("FileSystemError")(
+class FileSystemError extends Schema.TaggedErrorClass<FileSystemError>()(
   "FileSystemError",
   { cause: Schema.optional(Schema.Unknown) }
 ) {}
 
-class FileSystem extends ServiceMap.Service<FileSystem, {
+class FileSystem extends Context.Service<FileSystem, {
   readonly use: <A>(fn: (fs: typeof fs_, signal: AbortSignal) => Promise<A>) => Effect.Effect<A, FileSystemError>
 }>()("FileSystem") {
   static readonly Default = Layer.effect(
@@ -273,5 +273,5 @@ See [Testing with Vitest](./08-testing.md) for more testing patterns.
 ## Related
 
 - [Error Handling](./06-error-handling.md) for `Schema.TaggedErrorClass` and `Schema.Defect`
-- [Services & Layers](./04-services-and-layers.md) for `ServiceMap.Service` and layer composition
+- [Services & Layers](./04-services-and-layers.md) for `Context.Service` and layer composition
 - [Config](./07-config.md) for loading configuration in services

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -14,11 +14,11 @@
     "generate:og": "bun ./scripts/generate-og.ts"
   },
   "dependencies": {
-    "@effect/platform-browser": "beta",
+    "@effect/platform-browser": "4.0.0-beta.57",
     "@phosphor-icons/react": "^2.1.10",
     "@tailwindcss/typography": "^0.5.19",
     "@vercel/analytics": "^2.0.1",
-    "effect": "beta",
+    "effect": "4.0.0-beta.57",
     "motion": "^12.38.0",
     "next": "16.1.7",
     "overlayscrollbars": "^2.14.0",
@@ -28,7 +28,7 @@
     "shiki": "^4.0.2"
   },
   "devDependencies": {
-    "@effect/platform-bun": "beta",
+    "@effect/platform-bun": "4.0.0-beta.57",
     "@biomejs/biome": "2.4.7",
     "@tailwindcss/postcss": "^4.2.1",
     "@types/hast": "^3.0.4",

--- a/packages/website/scripts/generate-og/browser.ts
+++ b/packages/website/scripts/generate-og/browser.ts
@@ -1,4 +1,4 @@
-import { Console, Effect, Layer, ServiceMap } from "effect"
+import { Console, Context, Effect, Layer } from "effect"
 import type { Browser as PlaywrightBrowser } from "playwright"
 import { chromium } from "playwright"
 
@@ -6,7 +6,7 @@ import { chromium } from "playwright"
 // Browser Service
 // =============================================================================
 
-export class Browser extends ServiceMap.Service<Browser, PlaywrightBrowser>()("Browser") {
+export class Browser extends Context.Service<Browser, PlaywrightBrowser>()("Browser") {
   static layer = Layer.effect(
     Browser,
     Effect.acquireRelease(

--- a/packages/website/scripts/generate-og/main.ts
+++ b/packages/website/scripts/generate-og/main.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs"
-import { BunServices, BunRuntime } from "@effect/platform-bun"
+import { BunRuntime, BunServices } from "@effect/platform-bun"
 import { Console, Effect, Layer } from "effect"
 import { Browser } from "./browser.js"
 import { captureSpec } from "./capture.js"

--- a/packages/website/scripts/generate-og/template-server.ts
+++ b/packages/website/scripts/generate-og/template-server.ts
@@ -1,12 +1,7 @@
 import net from "node:net"
+import { Console, Context, Effect, Layer, Schedule, Stream } from "effect"
+import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { ChildProcess } from "effect/unstable/process"
-import {
-  FetchHttpClient,
-  HttpClient,
-  HttpClientRequest,
-  HttpClientResponse,
-} from "effect/unstable/http"
-import { Console, Effect, Layer, Schedule, ServiceMap, Stream } from "effect"
 import { getBaseUrl, NEXT_CACHE_DIR, TEMPLATE_ROUTE } from "./config.js"
 
 // =============================================================================
@@ -106,9 +101,7 @@ const acquireServer = Effect.gen(function* () {
 // Template Server Service
 // =============================================================================
 
-export class TemplateServer extends ServiceMap.Service<TemplateServer, { readonly baseUrl: string }>()(
-  "TemplateServer",
-) {
+export class TemplateServer extends Context.Service<TemplateServer, { readonly baseUrl: string }>()("TemplateServer") {
   static layer = Layer.effect(TemplateServer, acquireServer.pipe(Effect.map((handle) => ({ baseUrl: handle.baseUrl }))))
 
   static test = (baseUrl: string) => Layer.succeed(TemplateServer, TemplateServer.of({ baseUrl }))

--- a/packages/website/src/components/DocTocSidebar.tsx
+++ b/packages/website/src/components/DocTocSidebar.tsx
@@ -241,7 +241,6 @@ export function DocTocSidebar({ className, style, title: _title }: DocTocSidebar
   )
 
   const renderedItems = useMemo(() => {
-    const lineInset = railInset
     const lineHeight = railHeight
     const gapHeight = 14 // px gap carved out of the spine
     const minDotPercent = (gapHeight / 2 / lineHeight) * 100
@@ -257,7 +256,7 @@ export function DocTocSidebar({ className, style, title: _title }: DocTocSidebar
       showDot = true,
       showGap = true,
     ) => {
-      const y = lineInset + (percent / 100) * lineHeight
+      const y = RAIL_INSET + (percent / 100) * lineHeight
       const labelOffset = 20
       return (
         <div key={id}>
@@ -336,7 +335,7 @@ export function DocTocSidebar({ className, style, title: _title }: DocTocSidebar
     }
 
     return allItems
-  }, [items, activeId, articleHeight, handleClick, isHoveringNearby, railHeight, railInset])
+  }, [items, activeId, articleHeight, handleClick, isHoveringNearby, railHeight])
 
   if (renderedItems.length === 0) {
     return <aside className={cn("hidden 2xl:block pointer-events-none", className)} style={style} aria-hidden="true" />

--- a/packages/website/src/components/VerticalCutReveal.tsx
+++ b/packages/website/src/components/VerticalCutReveal.tsx
@@ -33,6 +33,18 @@ interface WordObject {
   needsSpace: boolean
 }
 
+interface RenderCharacter {
+  key: string
+  position: number
+  value: string
+}
+
+interface RenderWord {
+  characters: RenderCharacter[]
+  key: string
+  needsSpace: boolean
+}
+
 const CHARACTER_MOTION_STYLE = {
   willChange: "transform",
 } as const
@@ -147,6 +159,41 @@ const VerticalCutReveal = forwardRef<VerticalCutRevealRef, TextProps>(
     }
 
     const Component = onClick ? "button" : "span"
+    const renderWords = useMemo<RenderWord[]>(() => {
+      const words =
+        splitBy === "characters"
+          ? (elements as WordObject[])
+          : (elements as string[]).map((el, i) => ({
+              characters: [el],
+              needsSpace: i !== elements.length - 1,
+            }))
+
+      let absolutePosition = 0
+
+      return words.map((word) => {
+        const start = absolutePosition
+        const characters = word.characters.map((char) => {
+          const position = absolutePosition
+          absolutePosition += 1
+
+          return {
+            key: `char-${position}-${char}`,
+            position,
+            value: char,
+          }
+        })
+
+        if (word.needsSpace) {
+          absolutePosition += 1
+        }
+
+        return {
+          characters,
+          key: `word-${start}-${word.characters.join("")}`,
+          needsSpace: word.needsSpace,
+        }
+      })
+    }, [elements, splitBy])
 
     return (
       <Component
@@ -157,28 +204,17 @@ const VerticalCutReveal = forwardRef<VerticalCutRevealRef, TextProps>(
       >
         <span className="sr-only">{text}</span>
 
-        {(splitBy === "characters"
-          ? (elements as WordObject[])
-          : (elements as string[]).map((el, i) => ({
-              characters: [el],
-              needsSpace: i !== elements.length - 1,
-            }))
-        ).map((wordObj, wordIndex, array) => {
-          const previousCharsCount = array.slice(0, wordIndex).reduce((sum, word) => sum + word.characters.length, 0)
-
+        {renderWords.map((wordObj, wordIndex, array) => {
           return (
             <span
-              key={`word-${wordIndex}-${wordObj.characters.join("")}`}
+              key={wordObj.key}
               aria-hidden="true"
               className={cn("inline-flex overflow-hidden", wordLevelClassName)}
             >
               {wordObj.characters.map((char, charIndex) => (
-                <span
-                  className={cn(elementLevelClassName, "relative")}
-                  key={`char-${previousCharsCount + charIndex}-${char}`}
-                >
+                <span className={cn(elementLevelClassName, "relative")} key={char.key}>
                   <motion.span
-                    custom={previousCharsCount + charIndex}
+                    custom={char.position}
                     initial="hidden"
                     animate="visible"
                     exit="exit"
@@ -189,7 +225,7 @@ const VerticalCutReveal = forwardRef<VerticalCutRevealRef, TextProps>(
                     style={CHARACTER_MOTION_STYLE}
                     className="inline-block"
                   >
-                    {char === " " ? "\u00A0" : char}
+                    {char.value === " " ? "\u00A0" : char.value}
                   </motion.span>
                 </span>
               ))}

--- a/packages/website/src/components/mdx/Terminal/commands.ts
+++ b/packages/website/src/components/mdx/Terminal/commands.ts
@@ -1,5 +1,5 @@
-import { Argument, Command, Flag } from "effect/unstable/cli"
 import { Console, Effect, Exit, Layer, Option } from "effect"
+import { Argument, Command, Flag } from "effect/unstable/cli"
 import { TaskId, TaskRepo } from "./domain"
 import { BrowserRuntime, log, MockTerminalLayer, makeMockConsole, TerminalOutput, TerminalOutputLive } from "./services"
 
@@ -43,7 +43,10 @@ const listCommand = Command.make("list", { all: allOption }, ({ all }) =>
 ).pipe(Command.withDescription("List pending tasks"))
 
 // toggle <id>
-const idArg = Argument.integer("id").pipe(Argument.withSchema(TaskId), Argument.withDescription("The task ID to toggle"))
+const idArg = Argument.integer("id").pipe(
+  Argument.withSchema(TaskId),
+  Argument.withDescription("The task ID to toggle"),
+)
 
 const toggleCommand = Command.make("toggle", { id: idArg }, ({ id }) =>
   Effect.gen(function* () {

--- a/packages/website/src/components/mdx/Terminal/domain.ts
+++ b/packages/website/src/components/mdx/Terminal/domain.ts
@@ -1,4 +1,4 @@
-import { type Effect, Option, Schema, ServiceMap } from "effect"
+import { Context, type Effect, Option, Schema } from "effect"
 
 // =============================================================================
 // Task Schema & Domain
@@ -24,8 +24,8 @@ export class TaskList extends Schema.Class<TaskList>("TaskList")({
   static empty = new TaskList({ tasks: [] })
 
   get nextId(): TaskId {
-    if (this.tasks.length === 0) return TaskId.makeUnsafe(1)
-    return TaskId.makeUnsafe(Math.max(...this.tasks.map((t) => t.id)) + 1)
+    if (this.tasks.length === 0) return TaskId.make(1)
+    return TaskId.make(Math.max(...this.tasks.map((t) => t.id)) + 1)
   }
 
   add(text: string): [TaskList, Task] {
@@ -49,7 +49,7 @@ export class TaskList extends Schema.Class<TaskList>("TaskList")({
 // TaskRepo Service
 // =============================================================================
 
-export class TaskRepo extends ServiceMap.Service<
+export class TaskRepo extends Context.Service<
   TaskRepo,
   {
     readonly list: (all?: boolean) => Effect.Effect<ReadonlyArray<Task>>

--- a/packages/website/src/components/mdx/Terminal/index.tsx
+++ b/packages/website/src/components/mdx/Terminal/index.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { KeyValueStore } from "effect/unstable/persistence"
-import type { KeyValueStore as KVS } from "effect/unstable/persistence"
 import { BrowserKeyValueStore } from "@effect/platform-browser"
 import { Effect } from "effect"
+import type { KeyValueStore as KVS } from "effect/unstable/persistence"
+import { KeyValueStore } from "effect/unstable/persistence"
 import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { GITHUB_REPO_URL } from "@/constants/urls"

--- a/packages/website/src/components/mdx/Terminal/services.ts
+++ b/packages/website/src/components/mdx/Terminal/services.ts
@@ -1,9 +1,19 @@
-import { KeyValueStore } from "effect/unstable/persistence"
-import { Terminal, Stdio } from "effect"
-import { FileSystem, Path } from "effect"
-import { ChildProcessSpawner } from "effect/unstable/process"
 import { BrowserKeyValueStore } from "@effect/platform-browser"
-import { Console, Effect, Layer, ManagedRuntime, Option, Ref, ServiceMap } from "effect"
+import {
+  type Console,
+  Context,
+  Effect,
+  FileSystem,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Path,
+  Ref,
+  Stdio,
+  Terminal,
+} from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import { ChildProcessSpawner } from "effect/unstable/process"
 import { Task, TaskId, TaskList, TaskRepo } from "./domain"
 
 // =============================================================================
@@ -16,12 +26,12 @@ const INITIALIZED_KEY = "effect-solutions-tasks-initialized"
 const DEFAULT_TASKS = new TaskList({
   tasks: [
     new Task({
-      id: TaskId.makeUnsafe(1),
+      id: TaskId.make(1),
       text: "Run the agent-guided setup",
       done: false,
     }),
     new Task({
-      id: TaskId.makeUnsafe(2),
+      id: TaskId.make(2),
       text: "Become effect-pilled",
       done: false,
     }),
@@ -74,7 +84,7 @@ const browserTaskRepoLayer = Layer.effect(
 // Terminal Output Service (line accumulator)
 // =============================================================================
 
-export class TerminalOutput extends ServiceMap.Service<
+export class TerminalOutput extends Context.Service<
   TerminalOutput,
   {
     readonly log: (...args: ReadonlyArray<unknown>) => Effect.Effect<void>
@@ -86,8 +96,13 @@ export class TerminalOutput extends ServiceMap.Service<
 export const TerminalOutputLive = Layer.sync(TerminalOutput, () => {
   const lines: string[] = []
   return TerminalOutput.of({
-    log: (...args) => Effect.sync(() => { for (const a of args) lines.push(String(a)) }),
-    logSync: (...args) => { for (const a of args) lines.push(String(a)) },
+    log: (...args) =>
+      Effect.sync(() => {
+        for (const a of args) lines.push(String(a))
+      }),
+    logSync: (...args) => {
+      for (const a of args) lines.push(String(a))
+    },
     getLines: Effect.sync(() => [...lines]),
   })
 })
@@ -157,9 +172,7 @@ const mockPathLayer = Path.layer
 const mockStdioLayer = Stdio.layerTest({})
 const mockSpawnerLayer = Layer.succeed(
   ChildProcessSpawner.ChildProcessSpawner,
-  ChildProcessSpawner.make(
-    () => Effect.die("ChildProcessSpawner not available in browser"),
-  ),
+  ChildProcessSpawner.make(() => Effect.die("ChildProcessSpawner not available in browser")),
 )
 
 // Combined browser platform layer (without Terminal - that needs TerminalOutput)

--- a/scripts/changeset-named.ts
+++ b/scripts/changeset-named.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 
-import { Argument, Command, Flag } from "effect/unstable/cli"
 import { BunRuntime, BunServices } from "@effect/platform-bun"
 import { Effect, FileSystem, pipe } from "effect"
+import { Argument, Command, Flag } from "effect/unstable/cli"
 
 const PACKAGES = {
   website: "@effect-best-practices/website",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env bun
 
-import { Command } from "effect/unstable/cli"
 import { BunRuntime, BunServices } from "@effect/platform-bun"
 // biome-ignore lint/suspicious/noShadowRestrictedNames: Effect convention
 import { Array, Effect, FileSystem, pipe, String } from "effect"
+import { Command } from "effect/unstable/cli"
 
 const exec = (cmd: string) => Effect.promise(() => Bun.$`sh -c ${cmd}`.text())
 

--- a/scripts/typecheck-docs.ts
+++ b/scripts/typecheck-docs.ts
@@ -92,11 +92,70 @@ async function main() {
 
   // Shared prelude so snippets can rely on common imports without cluttering docs
   const prelude = `
-/// <reference types="@effect/vitest/globals" />
-import { Effect, Schema, Layer, Config, ConfigError, Console, Option, Match, Redacted, HttpClient, HttpClientResponse, FetchHttpClient } from "effect";
-import { Argument, Command, Flag } from "effect/unstable/cli";
-import { BunRuntime, BunServices } from "@effect/platform-bun";
-export const __prelude = { Effect, Schema, Layer, Config, ConfigError, Console, Option, Match, Redacted, Argument, Command, Flag, HttpClient, HttpClientResponse, FetchHttpClient, BunRuntime, BunServices };
+import { Clock as _Clock, Config as _Config, Console as _Console, Context as _Context, Effect as _Effect, Layer as _Layer, Logger as _Logger, Match as _Match, Option as _Option, Redacted as _Redacted, Schema as _Schema } from "effect";
+import { describe as _describe, expect as _expect, it as _it } from "@effect/vitest";
+import { Argument as _Argument, Command as _Command, Flag as _Flag } from "effect/unstable/cli";
+import { BunRuntime as _BunRuntime, BunServices as _BunServices } from "@effect/platform-bun";
+declare global {
+  const Clock: typeof _Clock;
+  const Config: typeof _Config;
+  const Console: typeof _Console;
+  const Context: typeof _Context;
+  const describe: typeof _describe;
+  const Effect: typeof _Effect;
+  const expect: typeof _expect;
+  const it: typeof _it;
+  const Layer: typeof _Layer;
+  const Logger: typeof _Logger;
+  const Match: typeof _Match;
+  const Redacted: typeof _Redacted;
+  const Schema: typeof _Schema;
+  const Argument: typeof _Argument;
+  const Command: typeof _Command;
+  const Flag: typeof _Flag;
+  const BunRuntime: typeof _BunRuntime;
+  const BunServices: typeof _BunServices;
+}
+Object.assign(globalThis, {
+  Clock: _Clock,
+  Config: _Config,
+  Console: _Console,
+  Context: _Context,
+  describe: _describe,
+  Effect: _Effect,
+  expect: _expect,
+  it: _it,
+  Layer: _Layer,
+  Logger: _Logger,
+  Match: _Match,
+  Redacted: _Redacted,
+  Schema: _Schema,
+  Argument: _Argument,
+  Command: _Command,
+  Flag: _Flag,
+  BunRuntime: _BunRuntime,
+  BunServices: _BunServices,
+});
+export const __prelude = {
+  Clock: _Clock,
+  Config: _Config,
+  Console: _Console,
+  Context: _Context,
+  describe: _describe,
+  Effect: _Effect,
+  expect: _expect,
+  it: _it,
+  Layer: _Layer,
+  Logger: _Logger,
+  Match: _Match,
+  Redacted: _Redacted,
+  Schema: _Schema,
+  Argument: _Argument,
+  Command: _Command,
+  Flag: _Flag,
+  BunRuntime: _BunRuntime,
+  BunServices: _BunServices,
+};
 `
   await writeFile(join(TEMP_DIR, "prelude.ts"), prelude)
 
@@ -118,7 +177,6 @@ export const __prelude = { Effect, Schema, Layer, Config, ConfigError, Console, 
       lib: ["ES2022", "DOM"],
       noEmit: true,
       skipLibCheck: true,
-      types: ["@effect/vitest/globals"],
       // Ensure every snippet is treated as an isolated module
       moduleDetection: "force",
     },

--- a/tests/03-basics.test.ts
+++ b/tests/03-basics.test.ts
@@ -184,7 +184,7 @@ describe("03-basics", () => {
           return Effect.succeed("ok")
         })
 
-        const retryPolicy = Schedule.exponential("1 millis").pipe(Schedule.compose(Schedule.recurs(3)))
+        const retryPolicy = Schedule.exponential("1 millis").pipe(Schedule.both(Schedule.recurs(3)))
 
         const fiber = yield* flaky.pipe(Effect.retry(retryPolicy), Effect.forkChild)
         yield* TestClock.adjust("100 millis")
@@ -201,7 +201,7 @@ describe("03-basics", () => {
           Effect.as("done"),
           Effect.timeoutOrElse({
             duration: "10 millis",
-            onTimeout: () => Effect.fail("timeout" as const),
+            orElse: () => Effect.fail("timeout" as const),
           }),
         )
 

--- a/tests/04-services-and-layers.test.ts
+++ b/tests/04-services-and-layers.test.ts
@@ -1,12 +1,12 @@
 import { describe, it } from "@effect/vitest"
 import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
-import { Effect, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 
 describe("04-services-and-layers", () => {
   describe("Service Definition", () => {
-    it.effect("defines service with ServiceMap.Service", () =>
+    it.effect("defines service with Context.Service", () =>
       Effect.gen(function* () {
-        class Database extends ServiceMap.Service<
+        class Database extends Context.Service<
           Database,
           {
             readonly query: (sql: string) => Effect.Effect<unknown[]>
@@ -14,7 +14,7 @@ describe("04-services-and-layers", () => {
           }
         >()("@app/Database") {}
 
-        class Logger extends ServiceMap.Service<
+        class Logger extends Context.Service<
           Logger,
           {
             readonly log: (message: string) => Effect.Effect<void>
@@ -50,9 +50,9 @@ describe("04-services-and-layers", () => {
   describe("Layer Implementation", () => {
     it.effect("creates layer with Layer.effect", () =>
       Effect.gen(function* () {
-        class Config extends ServiceMap.Service<Config, { readonly apiUrl: string }>()("@app/Config") {}
+        class Config extends Context.Service<Config, { readonly apiUrl: string }>()("@app/Config") {}
 
-        class Api extends ServiceMap.Service<Api, { readonly fetch: (path: string) => Effect.Effect<string> }>()(
+        class Api extends Context.Service<Api, { readonly fetch: (path: string) => Effect.Effect<string> }>()(
           "@app/Api",
         ) {
           static readonly layer = Layer.effect(
@@ -84,12 +84,11 @@ describe("04-services-and-layers", () => {
 
     it.effect("composes layers with dependencies", () =>
       Effect.gen(function* () {
-        class Logger extends ServiceMap.Service<
-          Logger,
-          { readonly log: (msg: string) => Effect.Effect<void> }
-        >()("@app/Logger") {}
+        class Logger extends Context.Service<Logger, { readonly log: (msg: string) => Effect.Effect<void> }>()(
+          "@app/Logger",
+        ) {}
 
-        class Analytics extends ServiceMap.Service<
+        class Analytics extends Context.Service<
           Analytics,
           { readonly track: (event: string) => Effect.Effect<void> }
         >()("@app/Analytics") {
@@ -134,7 +133,7 @@ describe("04-services-and-layers", () => {
   describe("Test Implementations", () => {
     it.effect("creates test layer with Layer.sync", () =>
       Effect.gen(function* () {
-        class Database extends ServiceMap.Service<
+        class Database extends Context.Service<
           Database,
           {
             readonly query: (sql: string) => Effect.Effect<unknown[]>
@@ -174,7 +173,7 @@ describe("04-services-and-layers", () => {
 
     it.effect("uses Layer.succeed for simple mocks", () =>
       Effect.gen(function* () {
-        class EmailService extends ServiceMap.Service<
+        class EmailService extends Context.Service<
           EmailService,
           { readonly send: (to: string, body: string) => Effect.Effect<void> }
         >()("@app/EmailService") {}
@@ -206,7 +205,7 @@ describe("04-services-and-layers", () => {
   describe("Effect.fn within Services", () => {
     it.effect("uses Effect.fn for service methods with tracing", () =>
       Effect.gen(function* () {
-        class UserRepo extends ServiceMap.Service<
+        class UserRepo extends Context.Service<
           UserRepo,
           {
             readonly findById: (id: string) => Effect.Effect<{ id: string; name: string }>
@@ -250,10 +249,9 @@ describe("04-services-and-layers", () => {
           id: Schema.String,
         }) {}
 
-        class Repo extends ServiceMap.Service<
-          Repo,
-          { readonly findById: (id: string) => Effect.Effect<string> }
-        >()("@app/Repo") {
+        class Repo extends Context.Service<Repo, { readonly findById: (id: string) => Effect.Effect<string> }>()(
+          "@app/Repo",
+        ) {
           static readonly layer = Layer.succeed(Repo, {
             findById: Effect.fn("Repo.findById")(
               function* (id: string) {
@@ -279,21 +277,21 @@ describe("04-services-and-layers", () => {
     it.effect("orchestrates multiple leaf services", () =>
       Effect.gen(function* () {
         // Leaf services
-        class Users extends ServiceMap.Service<
+        class Users extends Context.Service<
           Users,
           {
             readonly findById: (id: string) => Effect.Effect<{ id: string; name: string }>
           }
         >()("@app/Users") {}
 
-        class Notifications extends ServiceMap.Service<
+        class Notifications extends Context.Service<
           Notifications,
           {
             readonly send: (userId: string, message: string) => Effect.Effect<void>
           }
         >()("@app/Notifications") {}
 
-        class Analytics extends ServiceMap.Service<
+        class Analytics extends Context.Service<
           Analytics,
           {
             readonly track: (event: string, data: unknown) => Effect.Effect<void>
@@ -301,7 +299,7 @@ describe("04-services-and-layers", () => {
         >()("@app/Analytics") {}
 
         // Higher-level orchestration service
-        class UserService extends ServiceMap.Service<
+        class UserService extends Context.Service<
           UserService,
           {
             readonly activate: (userId: string) => Effect.Effect<{ id: string; name: string }>
@@ -367,12 +365,12 @@ describe("04-services-and-layers", () => {
     it.effect("design with services first - contracts before implementations", () =>
       Effect.gen(function* () {
         // Define service contracts without implementations
-        class EmailService extends ServiceMap.Service<
+        class EmailService extends Context.Service<
           EmailService,
           { readonly send: (to: string, body: string) => Effect.Effect<void> }
         >()("@app/EmailService") {}
 
-        class PaymentService extends ServiceMap.Service<
+        class PaymentService extends Context.Service<
           PaymentService,
           {
             readonly charge: (userId: string, amount: number) => Effect.Effect<string>
@@ -380,7 +378,7 @@ describe("04-services-and-layers", () => {
         >()("@app/PaymentService") {}
 
         // Higher-level service that uses the contracts
-        class CheckoutService extends ServiceMap.Service<
+        class CheckoutService extends Context.Service<
           CheckoutService,
           {
             readonly process: (userId: string, amount: number) => Effect.Effect<string>
@@ -431,15 +429,13 @@ describe("04-services-and-layers", () => {
   describe("Service Composition", () => {
     it.effect("merges independent layers", () =>
       Effect.gen(function* () {
-        class ServiceA extends ServiceMap.Service<
-          ServiceA,
-          { readonly getValue: () => Effect.Effect<string> }
-        >()("@app/ServiceA") {}
+        class ServiceA extends Context.Service<ServiceA, { readonly getValue: () => Effect.Effect<string> }>()(
+          "@app/ServiceA",
+        ) {}
 
-        class ServiceB extends ServiceMap.Service<
-          ServiceB,
-          { readonly getValue: () => Effect.Effect<number> }
-        >()("@app/ServiceB") {}
+        class ServiceB extends Context.Service<ServiceB, { readonly getValue: () => Effect.Effect<number> }>()(
+          "@app/ServiceB",
+        ) {}
 
         const layerA = Layer.succeed(ServiceA, {
           getValue: () => Effect.succeed("A"),
@@ -465,9 +461,9 @@ describe("04-services-and-layers", () => {
 
     it.effect("chains dependent layers", () =>
       Effect.gen(function* () {
-        class Config extends ServiceMap.Service<Config, { readonly prefix: string }>()("@app/Config") {}
+        class Config extends Context.Service<Config, { readonly prefix: string }>()("@app/Config") {}
 
-        class Formatter extends ServiceMap.Service<
+        class Formatter extends Context.Service<
           Formatter,
           { readonly format: (msg: string) => Effect.Effect<string> }
         >()("@app/Formatter") {
@@ -497,12 +493,11 @@ describe("04-services-and-layers", () => {
 
     it.effect("Layer.provide satisfies dependencies", () =>
       Effect.gen(function* () {
-        class Config extends ServiceMap.Service<Config, { readonly url: string }>()("@app/Config") {}
+        class Config extends Context.Service<Config, { readonly url: string }>()("@app/Config") {}
 
-        class Database extends ServiceMap.Service<
-          Database,
-          { readonly query: () => Effect.Effect<string> }
-        >()("@app/Database") {
+        class Database extends Context.Service<Database, { readonly query: () => Effect.Effect<string> }>()(
+          "@app/Database",
+        ) {
           static readonly layer = Layer.effect(
             Database,
             Effect.gen(function* () {
@@ -527,12 +522,9 @@ describe("04-services-and-layers", () => {
 
     it.effect("Layer.provideMerge exposes the provider", () =>
       Effect.gen(function* () {
-        class Config extends ServiceMap.Service<Config, { readonly env: string }>()("@app/Config") {}
+        class Config extends Context.Service<Config, { readonly env: string }>()("@app/Config") {}
 
-        class Logger extends ServiceMap.Service<
-          Logger,
-          { readonly log: () => Effect.Effect<string> }
-        >()("@app/Logger") {
+        class Logger extends Context.Service<Logger, { readonly log: () => Effect.Effect<string> }>()("@app/Logger") {
           static readonly layer = Layer.effect(
             Logger,
             Effect.gen(function* () {
@@ -561,17 +553,13 @@ describe("04-services-and-layers", () => {
   describe("Providing Layers to Effects", () => {
     it.effect("provide once at entry point", () =>
       Effect.gen(function* () {
-        class Config extends ServiceMap.Service<Config, { readonly name: string }>()("@app/Config") {}
+        class Config extends Context.Service<Config, { readonly name: string }>()("@app/Config") {}
 
-        class Logger extends ServiceMap.Service<
-          Logger,
-          { readonly info: (msg: string) => Effect.Effect<void> }
-        >()("@app/Logger") {}
+        class Logger extends Context.Service<Logger, { readonly info: (msg: string) => Effect.Effect<void> }>()(
+          "@app/Logger",
+        ) {}
 
-        class App extends ServiceMap.Service<
-          App,
-          { readonly run: () => Effect.Effect<string> }
-        >()("@app/App") {
+        class App extends Context.Service<App, { readonly run: () => Effect.Effect<string> }>()("@app/App") {
           static readonly layer = Layer.effect(
             App,
             Effect.gen(function* () {
@@ -620,17 +608,15 @@ describe("04-services-and-layers", () => {
       Effect.gen(function* () {
         let constructionCount = 0
 
-        class Expensive extends ServiceMap.Service<Expensive, { readonly id: number }>()("@app/Expensive") {}
+        class Expensive extends Context.Service<Expensive, { readonly id: number }>()("@app/Expensive") {}
 
-        class ServiceA extends ServiceMap.Service<
-          ServiceA,
-          { readonly getValue: () => Effect.Effect<number> }
-        >()("@app/ServiceA") {}
+        class ServiceA extends Context.Service<ServiceA, { readonly getValue: () => Effect.Effect<number> }>()(
+          "@app/ServiceA",
+        ) {}
 
-        class ServiceB extends ServiceMap.Service<
-          ServiceB,
-          { readonly getValue: () => Effect.Effect<number> }
-        >()("@app/ServiceB") {}
+        class ServiceB extends Context.Service<ServiceB, { readonly getValue: () => Effect.Effect<number> }>()(
+          "@app/ServiceB",
+        ) {}
 
         // Shared layer as a constant
         const ExpensiveLive = Layer.effect(
@@ -682,7 +668,7 @@ describe("04-services-and-layers", () => {
       Effect.gen(function* () {
         let constructionCount = 0
 
-        class Shared extends ServiceMap.Service<Shared, { readonly id: number }>()("@app/Shared") {}
+        class Shared extends Context.Service<Shared, { readonly id: number }>()("@app/Shared") {}
 
         const makeSharedLayer = () =>
           Layer.effect(
@@ -693,9 +679,9 @@ describe("04-services-and-layers", () => {
             }),
           )
 
-        class ServiceA extends ServiceMap.Service<ServiceA, { readonly id: number }>()("@app/ServiceA") {}
+        class ServiceA extends Context.Service<ServiceA, { readonly id: number }>()("@app/ServiceA") {}
 
-        class ServiceB extends ServiceMap.Service<ServiceB, { readonly id: number }>()("@app/ServiceB") {}
+        class ServiceB extends Context.Service<ServiceB, { readonly id: number }>()("@app/ServiceB") {}
 
         // Bad: inline calls create different references
         const ServiceALive = Layer.effect(
@@ -733,7 +719,7 @@ describe("04-services-and-layers", () => {
   })
 
   describe("it.layer", () => {
-    class Counter extends ServiceMap.Service<
+    class Counter extends Context.Service<
       Counter,
       {
         readonly get: () => Effect.Effect<number>

--- a/tests/05-data-modeling.test.ts
+++ b/tests/05-data-modeling.test.ts
@@ -23,7 +23,7 @@ describe("05-data-modeling", () => {
 
       // Usage
       const user = new User({
-        id: UserId.makeUnsafe("user-123"),
+        id: UserId.make("user-123"),
         name: "Alice",
         email: "alice@example.com",
         createdAt: new Date("2025-01-01T00:00:00.000Z"),
@@ -113,18 +113,15 @@ describe("05-data-modeling", () => {
       const Email = Schema.String.pipe(Schema.brand("Email"))
       type Email = typeof Email.Type
 
-      const Port = Schema.Int.pipe(
-        Schema.check(Schema.isBetween({ minimum: 1, maximum: 65535 })),
-        Schema.brand("Port"),
-      )
+      const Port = Schema.Int.pipe(Schema.check(Schema.isBetween({ minimum: 1, maximum: 65535 })), Schema.brand("Port"))
       // biome-ignore lint/correctness/noUnusedVariables: Used for type annotation
       type Port = typeof Port.Type
 
       // Usage - impossible to mix types
-      const userId = UserId.makeUnsafe("user-123")
-      const _postId = PostId.makeUnsafe("post-456")
-      const email = Email.makeUnsafe("alice@example.com")
-      const port = Port.makeUnsafe(8080)
+      const userId = UserId.make("user-123")
+      const _postId = PostId.make("post-456")
+      const email = Email.make("alice@example.com")
+      const port = Port.make(8080)
 
       function getUser(id: UserId) {
         return id
@@ -152,15 +149,15 @@ describe("05-data-modeling", () => {
         {
           fromUrl(url: string): Option.Option<typeof GitHubUsername.Type> {
             const match = url.match(/github\.com\/([^/]+)/)
-            return match ? Option.some(GitHubUsername.makeUnsafe(match[1])) : Option.none()
+            return match ? Option.some(GitHubUsername.make(match[1])) : Option.none()
           },
           toProfileUrl: (u: typeof GitHubUsername.Type) => `https://github.com/${u}`,
         },
       )
       type GitHubUsername = typeof GitHubUsername.Type
 
-      // .makeUnsafe() works
-      const username = GitHubUsername.makeUnsafe("octocat")
+      // .make() works
+      const username = GitHubUsername.make("octocat")
       strictEqual(username, "octocat")
 
       // Custom methods work
@@ -178,7 +175,7 @@ describe("05-data-modeling", () => {
       // Schema validation still works
       let threw = false
       try {
-        GitHubUsername.makeUnsafe("invalid--username") // double hyphen not allowed
+        GitHubUsername.make("invalid--username") // double hyphen not allowed
       } catch {
         threw = true
       }

--- a/tests/07-config.test.ts
+++ b/tests/07-config.test.ts
@@ -329,6 +329,47 @@ describe("07-config", () => {
         strictEqual(result, "my-secret")
       }),
     )
+
+    it.effect("parses comma-separated arrays from string config", () =>
+      Effect.gen(function* () {
+        const program = Effect.gen(function* () {
+          return yield* Config.string("TAGS").pipe(
+            Config.map((value) =>
+              value
+                .split(",")
+                .map((tag) => tag.trim())
+                .filter((tag) => tag.length > 0),
+            ),
+          )
+        })
+
+        const testConfig = ConfigProvider.fromUnknown({ TAGS: "docs, effect, , config" })
+
+        const result = yield* program.pipe(Effect.provide(ConfigProvider.layer(testConfig)))
+
+        strictEqual(result.length, 3)
+        strictEqual(result[0], "docs")
+        strictEqual(result[1], "effect")
+        strictEqual(result[2], "config")
+      }),
+    )
+
+    it.effect("reads arrays from structured config providers with Config.schema", () =>
+      Effect.gen(function* () {
+        const program = Effect.gen(function* () {
+          return yield* Config.schema(Schema.Array(Schema.String), "TAGS")
+        })
+
+        const testConfig = ConfigProvider.fromUnknown({ TAGS: ["docs", "effect", "config"] })
+
+        const result = yield* program.pipe(Effect.provide(ConfigProvider.layer(testConfig)))
+
+        strictEqual(result.length, 3)
+        strictEqual(result[0], "docs")
+        strictEqual(result[1], "effect")
+        strictEqual(result[2], "config")
+      }),
+    )
   })
 
   describe("Complex Config Scenarios", () => {

--- a/tests/07-config.test.ts
+++ b/tests/07-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertSome, assertTrue, strictEqual } from "@effect/vitest/utils"
-import { Config, ConfigProvider, Effect, Layer, Redacted, Schema, ServiceMap } from "effect"
+import { Config, ConfigProvider, Context, Effect, Layer, Redacted, Schema } from "effect"
 
 describe("07-config", () => {
   describe("Basic Config Usage", () => {
@@ -51,7 +51,7 @@ describe("07-config", () => {
   describe("Config Layer Pattern", () => {
     it.effect("creates config service with layer", () =>
       Effect.gen(function* () {
-        class ApiConfig extends ServiceMap.Service<
+        class ApiConfig extends Context.Service<
           ApiConfig,
           {
             readonly apiKey: Redacted.Redacted<string>
@@ -98,7 +98,7 @@ describe("07-config", () => {
 
     it.effect("uses real config with provider", () =>
       Effect.gen(function* () {
-        class DbConfig extends ServiceMap.Service<
+        class DbConfig extends Context.Service<
           DbConfig,
           {
             readonly host: string
@@ -334,7 +334,7 @@ describe("07-config", () => {
   describe("Complex Config Scenarios", () => {
     it.effect("combines multiple config sources", () =>
       Effect.gen(function* () {
-        class AppConfig extends ServiceMap.Service<
+        class AppConfig extends Context.Service<
           AppConfig,
           {
             readonly server: { port: number; host: string }

--- a/tests/08-testing.test.ts
+++ b/tests/08-testing.test.ts
@@ -1,7 +1,6 @@
-import { FileSystem } from "effect"
 import { NodeFileSystem } from "@effect/platform-node"
 import { describe, expect, it } from "@effect/vitest"
-import { Clock, Effect, Layer, Option, Schema, ServiceMap } from "effect"
+import { Clock, Context, Effect, FileSystem, Layer, Option, Schema } from "effect"
 
 describe("11-testing-with-vitest", () => {
   describe("Basic Testing", () => {
@@ -37,10 +36,9 @@ describe("11-testing-with-vitest", () => {
   })
 
   describe("Providing Layers", () => {
-    class Database extends ServiceMap.Service<
-      Database,
-      { query: (sql: string) => Effect.Effect<string[]> }
-    >()("Database") {}
+    class Database extends Context.Service<Database, { query: (sql: string) => Effect.Effect<string[]> }>()(
+      "Database",
+    ) {}
 
     const testDatabase = Layer.succeed(Database, {
       query: (_sql) => Effect.succeed(["mock", "data"]),
@@ -119,7 +117,7 @@ class UserNotFound extends Schema.TaggedErrorClass("UserNotFound")("UserNotFound
 }) {}
 
 // Users service with test layer that has create + findById
-class Users extends ServiceMap.Service<
+class Users extends Context.Service<
   Users,
   {
     readonly create: (user: User) => Effect.Effect<void>
@@ -144,7 +142,7 @@ class Users extends ServiceMap.Service<
 }
 
 // Tickets service with test layer
-class Tickets extends ServiceMap.Service<
+class Tickets extends Context.Service<
   Tickets,
   {
     readonly issue: (eventId: EventId, userId: UserId) => Effect.Effect<Ticket>
@@ -154,12 +152,13 @@ class Tickets extends ServiceMap.Service<
     let counter = 0
 
     const issue = (eventId: EventId, _userId: UserId) =>
-      Effect.sync(() =>
-        new Ticket({
-          id: TicketId.makeUnsafe(`ticket-${counter++}`),
-          eventId,
-          code: `CODE-${counter}`,
-        }),
+      Effect.sync(
+        () =>
+          new Ticket({
+            id: TicketId.make(`ticket-${counter++}`),
+            eventId,
+            code: `CODE-${counter}`,
+          }),
       )
 
     return { issue }
@@ -167,7 +166,7 @@ class Tickets extends ServiceMap.Service<
 }
 
 // Emails service with test layer that tracks sent emails
-class Emails extends ServiceMap.Service<
+class Emails extends Context.Service<
   Emails,
   {
     readonly send: (email: Email) => Effect.Effect<void>
@@ -186,7 +185,7 @@ class Emails extends ServiceMap.Service<
 }
 
 // Events service orchestrates leaf services
-class Events extends ServiceMap.Service<
+class Events extends Context.Service<
   Events,
   {
     readonly register: (eventId: EventId, userId: UserId) => Effect.Effect<Registration, UserNotFound>
@@ -205,7 +204,7 @@ class Events extends ServiceMap.Service<
         const now = yield* Clock.currentTimeMillis
 
         const registration = new Registration({
-          id: RegistrationId.makeUnsafe(crypto.randomUUID()),
+          id: RegistrationId.make(crypto.randomUUID()),
           eventId,
           userId,
           ticketId: ticket.id,
@@ -243,14 +242,14 @@ describe("Events.register", () => {
 
       // Arrange: create a user
       const user = new User({
-        id: UserId.makeUnsafe("user-123"),
+        id: UserId.make("user-123"),
         name: "Alice",
         email: "alice@example.com",
       })
       yield* users.create(user)
 
       // Act
-      const eventId = EventId.makeUnsafe("event-789")
+      const eventId = EventId.make("event-789")
       const registration = yield* events.register(eventId, user.id)
 
       // Assert
@@ -267,14 +266,14 @@ describe("Events.register", () => {
 
       // Arrange
       const user = new User({
-        id: UserId.makeUnsafe("user-456"),
+        id: UserId.make("user-456"),
         name: "Bob",
         email: "bob@example.com",
       })
       yield* users.create(user)
 
       // Act
-      yield* events.register(EventId.makeUnsafe("event-789"), user.id)
+      yield* events.register(EventId.make("event-789"), user.id)
 
       // Assert: check sent emails
       const sentEmails = yield* emails.sent

--- a/tests/11-http-clients.test.ts
+++ b/tests/11-http-clients.test.ts
@@ -1,17 +1,7 @@
-import {
-  FetchHttpClient,
-  HttpClient,
-  HttpClientRequest,
-  HttpClientResponse,
-} from "effect/unstable/http"
-import {
-  HttpApi,
-  HttpApiClient,
-  HttpApiEndpoint,
-  HttpApiGroup,
-} from "effect/unstable/httpapi"
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, flow, Layer, Schema, ServiceMap } from "effect"
+import { Context, Effect, flow, Layer, Schema } from "effect"
+import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { HttpApi, HttpApiClient, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 
 // ============================================================================
 // Schemas
@@ -42,7 +32,7 @@ class Repo extends Schema.Class("Repo")({
 // API Service
 // ============================================================================
 
-class GitHubApi extends ServiceMap.Service<
+class GitHubApi extends Context.Service<
   GitHubApi,
   {
     readonly getUser: (username: string) => Effect.Effect<User, unknown>
@@ -82,25 +72,23 @@ class GitHubApi extends ServiceMap.Service<
 // HttpApi Definition
 // ============================================================================
 
-const UsersApi = HttpApiGroup.make("users")
-  .add(
-    HttpApiEndpoint.get("getUser", "/users/:username", {
-      params: { username: Schema.String },
-      success: User,
-    }),
-    HttpApiEndpoint.get("listRepos", "/users/:username/repos", {
-      params: { username: Schema.String },
-      success: Schema.Array(Repo),
-    }),
-  )
+const UsersApi = HttpApiGroup.make("users").add(
+  HttpApiEndpoint.get("getUser", "/users/:username", {
+    params: { username: Schema.String },
+    success: User,
+  }),
+  HttpApiEndpoint.get("listRepos", "/users/:username/repos", {
+    params: { username: Schema.String },
+    success: Schema.Array(Repo),
+  }),
+)
 
-const ReposApi = HttpApiGroup.make("repos")
-  .add(
-    HttpApiEndpoint.get("getRepo", "/repos/:owner/:repo", {
-      params: { owner: Schema.String, repo: Schema.String },
-      success: Repo,
-    }),
-  )
+const ReposApi = HttpApiGroup.make("repos").add(
+  HttpApiEndpoint.get("getRepo", "/repos/:owner/:repo", {
+    params: { owner: Schema.String, repo: Schema.String },
+    success: Repo,
+  }),
+)
 
 const GitHubHttpApi = HttpApi.make("github-api").add(UsersApi).add(ReposApi)
 

--- a/tests/14-use-pattern.test.ts
+++ b/tests/14-use-pattern.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@effect/vitest"
 import { assertTrue, strictEqual } from "@effect/vitest/utils"
-import { Effect, Layer, pipe, Result, Schema, ServiceMap } from "effect"
+import { Context, Effect, Layer, pipe, Result, Schema } from "effect"
 
 describe("14-use-pattern", () => {
   class FileSystemError extends Schema.TaggedErrorClass("FileSystemError")("FileSystemError", {
@@ -32,7 +32,7 @@ describe("14-use-pattern", () => {
     } satisfies MockFs
   }
 
-  class FileSystem extends ServiceMap.Service<
+  class FileSystem extends Context.Service<
     FileSystem,
     {
       readonly use: <A>(fn: (fs: MockFs, signal: AbortSignal) => Promise<A>) => Effect.Effect<A, FileSystemError>

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,9 +1,8 @@
-import { Argument, Command, Flag } from "effect/unstable/cli"
-import { FileSystem } from "effect"
 import { NodeServices } from "@effect/platform-node"
 import { describe, expect, it } from "@effect/vitest"
 // biome-ignore lint/suspicious/noShadowRestrictedNames: Effect convention
-import { Array, Effect, Layer, Option, Schema, ServiceMap } from "effect"
+import { Array, Context, Effect, FileSystem, Layer, Option, Schema } from "effect"
+import { Argument, Command, Flag } from "effect/unstable/cli"
 
 // ============================================================================
 // Task Schema
@@ -29,8 +28,8 @@ class TaskList extends Schema.Class("TaskList")({
   static empty = new TaskList({ tasks: [] })
 
   get nextId(): TaskId {
-    if (this.tasks.length === 0) return TaskId.makeUnsafe(1)
-    return TaskId.makeUnsafe(Math.max(...this.tasks.map((t) => t.id)) + 1)
+    if (this.tasks.length === 0) return TaskId.make(1)
+    return TaskId.make(Math.max(...this.tasks.map((t) => t.id)) + 1)
   }
 
   add(text: string): [TaskList, Task] {
@@ -65,7 +64,7 @@ class TaskList extends Schema.Class("TaskList")({
 // TaskRepo Service
 // ============================================================================
 
-class TaskRepo extends ServiceMap.Service<
+class TaskRepo extends Context.Service<
   TaskRepo,
   {
     readonly list: (all?: boolean) => Effect.Effect<ReadonlyArray<Task>>
@@ -118,7 +117,7 @@ class TaskRepo extends ServiceMap.Service<
 
   static testLayer = Layer.succeed(TaskRepo, {
     list: (_all?) => Effect.succeed([]),
-    add: (text) => Effect.succeed(new Task({ id: TaskId.makeUnsafe(1), text, done: false })),
+    add: (text) => Effect.succeed(new Task({ id: TaskId.make(1), text, done: false })),
     toggle: () => Effect.succeed(Option.none()),
   })
 }
@@ -160,7 +159,7 @@ const _app = Command.make("tasks").pipe(Command.withSubcommands([addCommand, lis
 describe("Domain Model", () => {
   describe("Task", () => {
     it("toggle flips done state", () => {
-      const task = new Task({ id: TaskId.makeUnsafe(1), text: "Test", done: false })
+      const task = new Task({ id: TaskId.make(1), text: "Test", done: false })
       const toggled = task.toggle()
 
       expect(toggled.done).toBe(true)
@@ -172,7 +171,7 @@ describe("Domain Model", () => {
     })
 
     it("toggle works both directions", () => {
-      const task = new Task({ id: TaskId.makeUnsafe(1), text: "Test", done: true })
+      const task = new Task({ id: TaskId.make(1), text: "Test", done: true })
       expect(task.toggle().done).toBe(false)
     })
   })
@@ -183,23 +182,23 @@ describe("Domain Model", () => {
     })
 
     it("nextId returns 1 for empty list", () => {
-      expect(TaskList.empty.nextId).toBe(TaskId.makeUnsafe(1))
+      expect(TaskList.empty.nextId).toBe(TaskId.make(1))
     })
 
     it("nextId returns max + 1", () => {
       const list = new TaskList({
         tasks: [
-          new Task({ id: TaskId.makeUnsafe(5), text: "A", done: false }),
-          new Task({ id: TaskId.makeUnsafe(3), text: "B", done: false }),
+          new Task({ id: TaskId.make(5), text: "A", done: false }),
+          new Task({ id: TaskId.make(3), text: "B", done: false }),
         ],
       })
-      expect(list.nextId).toBe(TaskId.makeUnsafe(6))
+      expect(list.nextId).toBe(TaskId.make(6))
     })
 
     it("add creates task with nextId", () => {
       const [list, task] = TaskList.empty.add("New task")
 
-      expect(task.id).toBe(TaskId.makeUnsafe(1))
+      expect(task.id).toBe(TaskId.make(1))
       expect(task.text).toBe("New task")
       expect(task.done).toBe(false)
       expect(list.tasks).toHaveLength(1)
@@ -209,14 +208,14 @@ describe("Domain Model", () => {
       const [list1, task1] = TaskList.empty.add("First")
       const [list2, task2] = list1.add("Second")
 
-      expect(task1.id).toBe(TaskId.makeUnsafe(1))
-      expect(task2.id).toBe(TaskId.makeUnsafe(2))
+      expect(task1.id).toBe(TaskId.make(1))
+      expect(task2.id).toBe(TaskId.make(2))
       expect(list2.tasks).toHaveLength(2)
     })
 
     it("toggle toggles task by id", () => {
       const [list] = TaskList.empty.add("Task")
-      const [newList, result] = list.toggle(TaskId.makeUnsafe(1))
+      const [newList, result] = list.toggle(TaskId.make(1))
 
       expect(Option.isSome(result)).toBe(true)
       if (Option.isSome(result)) {
@@ -226,13 +225,13 @@ describe("Domain Model", () => {
     })
 
     it("toggle returns none for missing id", () => {
-      const [, result] = TaskList.empty.toggle(TaskId.makeUnsafe(999))
+      const [, result] = TaskList.empty.toggle(TaskId.make(999))
       expect(Option.isNone(result)).toBe(true)
     })
 
     it("find returns task by id", () => {
       const [list] = TaskList.empty.add("Find me")
-      const found = list.find(TaskId.makeUnsafe(1))
+      const found = list.find(TaskId.make(1))
 
       expect(Option.isSome(found)).toBe(true)
       if (Option.isSome(found)) {
@@ -241,12 +240,12 @@ describe("Domain Model", () => {
     })
 
     it("find returns none for missing id", () => {
-      expect(Option.isNone(TaskList.empty.find(TaskId.makeUnsafe(1)))).toBe(true)
+      expect(Option.isNone(TaskList.empty.find(TaskId.make(1)))).toBe(true)
     })
 
     it("pending filters incomplete tasks", () => {
       let [list] = TaskList.empty.add("Done")
-      ;[list] = list.toggle(TaskId.makeUnsafe(1))
+      ;[list] = list.toggle(TaskId.make(1))
       ;[list] = list.add("Not done")
 
       expect(list.pending).toHaveLength(1)
@@ -255,7 +254,7 @@ describe("Domain Model", () => {
 
     it("completed filters done tasks", () => {
       let [list] = TaskList.empty.add("Done")
-      ;[list] = list.toggle(TaskId.makeUnsafe(1))
+      ;[list] = list.toggle(TaskId.make(1))
       ;[list] = list.add("Not done")
 
       expect(list.completed).toHaveLength(1)
@@ -353,7 +352,7 @@ describe("CLI", () => {
     it.effect("toggle returns Option", () =>
       Effect.gen(function* () {
         const repo = yield* TaskRepo
-        const result = yield* repo.toggle(TaskId.makeUnsafe(1))
+        const result = yield* repo.toggle(TaskId.make(1))
         expect(Option.isOption(result)).toBe(true)
       }).pipe(Effect.provide(TaskRepo.testLayer)),
     )
@@ -366,7 +365,12 @@ describe("CLI", () => {
         const tempDir = yield* fs.makeTempDirectoryScoped()
         const path = `${tempDir}/tasks.json`
 
-        const repo = yield* Effect.provide(Effect.gen(function* () { return yield* TaskRepo }), TaskRepo.layer(path).pipe(Layer.provide(NodeServices.layer)))
+        const repo = yield* Effect.provide(
+          Effect.gen(function* () {
+            return yield* TaskRepo
+          }),
+          TaskRepo.layer(path).pipe(Layer.provide(NodeServices.layer)),
+        )
 
         // Initially empty
         const before = yield* repo.list()
@@ -390,7 +394,12 @@ describe("CLI", () => {
         const tempDir = yield* fs.makeTempDirectoryScoped()
         const path = `${tempDir}/tasks.json`
 
-        const repo = yield* Effect.provide(Effect.gen(function* () { return yield* TaskRepo }), TaskRepo.layer(path).pipe(Layer.provide(NodeServices.layer)))
+        const repo = yield* Effect.provide(
+          Effect.gen(function* () {
+            return yield* TaskRepo
+          }),
+          TaskRepo.layer(path).pipe(Layer.provide(NodeServices.layer)),
+        )
 
         // Add and complete
         const task = yield* repo.add("Walk the dog")
@@ -415,13 +424,18 @@ describe("CLI", () => {
 
         // Pre-populate file
         const initial = new TaskList({
-          tasks: [new Task({ id: TaskId.makeUnsafe(1), text: "Existing", done: false })],
+          tasks: [new Task({ id: TaskId.make(1), text: "Existing", done: false })],
         })
         const json = yield* Schema.encodeEffect(TaskList.Json)(initial)
         yield* fs.writeFileString(path, json)
 
         // Load via repo
-        const repo = yield* Effect.provide(Effect.gen(function* () { return yield* TaskRepo }), TaskRepo.layer(path).pipe(Layer.provide(NodeServices.layer)))
+        const repo = yield* Effect.provide(
+          Effect.gen(function* () {
+            return yield* TaskRepo
+          }),
+          TaskRepo.layer(path).pipe(Layer.provide(NodeServices.layer)),
+        )
         const tasks = yield* repo.list()
 
         expect(tasks).toHaveLength(1)


### PR DESCRIPTION
## Summary
- pin the repo's Effect packages to `4.0.0-beta.57`
- migrate remaining `ServiceMap.Service` usage to `Context.Service`
- update docs, tests, and validation helpers for current v4 beta APIs, including schema constructors, tagged errors, schedules, CLI examples, and removing the old `Config.array` example in favor of the supported config array patterns
- correct the stale `bun test` instruction in `CONTRIBUTING.md`

## Testing
- bun run check
- bun run test