### PR TITLE
Update effect repository reference

### DIFF
--- a/.changeset/update-effect-github-repository-reference.md
+++ b/.changeset/update-effect-github-repository-reference.md
@@ -1,0 +1,5 @@
+---
+"effect-solutions": patch
+---
+
+Update effect GitHub repository reference from `Effect-TS/effect-smol` to `Effect-TS/effect` after V4 has been moved into the canonical repository

--- a/packages/website/docs/01-project-setup.md
+++ b/packages/website/docs/01-project-setup.md
@@ -88,10 +88,10 @@ Add to `package.json` to persist across installs:
 
 We recommend cloning the Effect source locally so your AI agent can grep through real implementations, type definitions, and patterns.
 
-The v4 source lives in [`Effect-TS/effect-smol`](https://github.com/Effect-TS/effect-smol). Clone it to a shared location to avoid re-cloning per project:
+The v4 source lives in [`Effect-TS/effect`](https://github.com/Effect-TS/effect). Clone it to a shared location to avoid re-cloning per project:
 
 ```bash
-git clone --depth 1 https://github.com/Effect-TS/effect-smol.git ~/.local/share/effect-solutions/effect
+git clone --depth 1 https://github.com/Effect-TS/effect.git ~/.local/share/effect-solutions/effect
 ```
 
 To update later: `git -C ~/.local/share/effect-solutions/effect pull --depth 1`

--- a/packages/website/src/lib/llm-instructions.ts
+++ b/packages/website/src/lib/llm-instructions.ts
@@ -117,7 +117,7 @@ Never guess at Effect patterns - check the guide first.
 Clone the Effect v4 source repository to a shared location so AI agents can search real implementations:
 
 \`\`\`bash
-git clone --depth 1 https://github.com/Effect-TS/effect-smol.git ~/.local/share/effect-solutions/effect
+git clone --depth 1 https://github.com/Effect-TS/effect.git ~/.local/share/effect-solutions/effect
 \`\`\`
 
 If the directory already exists, pull the latest changes:


### PR DESCRIPTION
This PR updates the effect repository reference to use [`github.com/Effect-TS/effect`](https://github.com/Effect-TS/effect) instead of [`github.com/Effect-TS/effect-smol`](https://github.com/Effect-TS/effect-smol).

The `Effect-TS/effect-smol` repository has been archived after it was merged into the main branch of `Effect-TS/effect`, see https://github.com/Effect-TS/effect-smol/pull/2620:

<img width="923" height="734" alt="image" src="https://github.com/user-attachments/assets/fe80cc31-69ba-48bf-a347-3439668292c0" />
